### PR TITLE
feat: implement batch operations for trade management

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,4 +14,6 @@ pub enum ContractError {
     Overflow = 8,
     NoFeesToWithdraw = 9,
     Unauthorized = 10,
+    BatchLimitExceeded = 11,
+    EmptyBatch = 12,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -61,3 +61,18 @@ pub fn emit_fees_withdrawn(env: &Env, amount: u64, to: Address) {
     env.events()
         .publish((symbol_short!("fees_out"),), (amount, to));
 }
+
+pub fn emit_batch_trades_created(env: &Env, count: u32, total_amount: u64) {
+    env.events()
+        .publish((symbol_short!("batch_cr"),), (count, total_amount));
+}
+
+pub fn emit_batch_trades_funded(env: &Env, count: u32, total_amount: u64) {
+    env.events()
+        .publish((symbol_short!("batch_fd"),), (count, total_amount));
+}
+
+pub fn emit_batch_trades_confirmed(env: &Env, count: u32, total_payout: u64, total_fees: u64) {
+    env.events()
+        .publish((symbol_short!("batch_cn"),), (count, total_payout, total_fees));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,197 @@ impl StellarEscrowContract {
     pub fn get_platform_fee_bps(env: Env) -> Result<u32, ContractError> {
         get_fee_bps(&env)
     }
+
+    /// Batch create trades - optimized for multiple trades
+    pub fn batch_create_trades(
+        env: Env,
+        seller: Address,
+        trades: soroban_sdk::Vec<(Address, u64, Option<Address>)>,
+    ) -> Result<soroban_sdk::Vec<u64>, ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+
+        // Enforce batch size limits (max 100 trades per batch for gas optimization)
+        if trades.is_empty() {
+            return Err(ContractError::EmptyBatch);
+        }
+        if trades.len() > 100 {
+            return Err(ContractError::BatchLimitExceeded);
+        }
+
+        seller.require_auth();
+
+        let fee_bps = get_fee_bps(&env)?;
+        let mut trade_ids = soroban_sdk::Vec::new(&env);
+        let mut total_amount: u64 = 0;
+
+        for (buyer, amount, arbitrator) in trades.iter() {
+            if amount == 0 {
+                return Err(ContractError::InvalidAmount);
+            }
+
+            if let Some(ref arb) = arbitrator {
+                if !has_arbitrator(&env, arb) {
+                    return Err(ContractError::ArbitratorNotRegistered);
+                }
+            }
+
+            let trade_id = increment_trade_counter(&env)?;
+            let fee = amount
+                .checked_mul(fee_bps as u64)
+                .ok_or(ContractError::Overflow)?
+                .checked_div(10000)
+                .ok_or(ContractError::Overflow)?;
+
+            let trade = Trade {
+                id: trade_id,
+                seller: seller.clone(),
+                buyer: buyer.clone(),
+                amount,
+                fee,
+                arbitrator,
+                status: TradeStatus::Created,
+            };
+
+            save_trade(&env, trade_id, &trade);
+            trade_ids.push_back(trade_id);
+            total_amount = total_amount.checked_add(amount).ok_or(ContractError::Overflow)?;
+        }
+
+        // Emit single batch event instead of multiple individual events
+        events::emit_batch_trades_created(&env, trade_ids.len() as u32, total_amount);
+
+        Ok(trade_ids)
+    }
+
+    /// Batch fund trades - optimized for multiple funding operations
+    pub fn batch_fund_trades(
+        env: Env,
+        buyer: Address,
+        trade_ids: soroban_sdk::Vec<u64>,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+
+        // Enforce batch size limits for gas optimization
+        if trade_ids.is_empty() {
+            return Err(ContractError::EmptyBatch);
+        }
+        if trade_ids.len() > 100 {
+            return Err(ContractError::BatchLimitExceeded);
+        }
+
+        buyer.require_auth();
+
+        let token = get_usdc_token(&env)?;
+        let token_client = token::Client::new(&env, &token);
+        let mut total_amount: u64 = 0;
+
+        // First pass: validate all trades and calculate total amount
+        for trade_id in trade_ids.iter() {
+            let trade = get_trade(&env, trade_id)?;
+
+            if trade.status != TradeStatus::Created {
+                return Err(ContractError::InvalidStatus);
+            }
+
+            if trade.buyer != buyer {
+                return Err(ContractError::Unauthorized);
+            }
+
+            total_amount = total_amount.checked_add(trade.amount).ok_or(ContractError::Overflow)?;
+        }
+
+        // Single transfer for all trades (gas optimization)
+        token_client.transfer(
+            &buyer,
+            &env.current_contract_address(),
+            &(total_amount as i128),
+        );
+
+        // Second pass: update trade statuses
+        for trade_id in trade_ids.iter() {
+            let mut trade = get_trade(&env, trade_id)?;
+            trade.status = TradeStatus::Funded;
+            save_trade(&env, trade_id, &trade);
+        }
+
+        // Emit single batch event
+        events::emit_batch_trades_funded(&env, trade_ids.len() as u32, total_amount);
+
+        Ok(())
+    }
+
+    /// Batch confirm trades - optimized for multiple confirmations
+    pub fn batch_confirm_trades(
+        env: Env,
+        buyer: Address,
+        trade_ids: soroban_sdk::Vec<u64>,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+
+        // Enforce batch size limits for gas optimization
+        if trade_ids.is_empty() {
+            return Err(ContractError::EmptyBatch);
+        }
+        if trade_ids.len() > 100 {
+            return Err(ContractError::BatchLimitExceeded);
+        }
+
+        buyer.require_auth();
+
+        let token = get_usdc_token(&env)?;
+        let token_client = token::Client::new(&env, &token);
+        let mut total_payout: u64 = 0;
+        let mut total_fees: u64 = 0;
+        let mut seller_payouts: soroban_sdk::Map<Address, u64> = soroban_sdk::Map::new(&env);
+
+        // First pass: validate all trades and calculate payouts
+        for trade_id in trade_ids.iter() {
+            let trade = get_trade(&env, trade_id)?;
+
+            if trade.status != TradeStatus::Completed {
+                return Err(ContractError::InvalidStatus);
+            }
+
+            if trade.buyer != buyer {
+                return Err(ContractError::Unauthorized);
+            }
+
+            let payout = trade.amount.checked_sub(trade.fee).ok_or(ContractError::Overflow)?;
+            total_payout = total_payout.checked_add(payout).ok_or(ContractError::Overflow)?;
+            total_fees = total_fees.checked_add(trade.fee).ok_or(ContractError::Overflow)?;
+
+            // Accumulate payouts per seller for efficient transfers
+            let current_payout = seller_payouts.get(&trade.seller).copied().unwrap_or(0);
+            let new_payout = current_payout.checked_add(payout).ok_or(ContractError::Overflow)?;
+            seller_payouts.set(&trade.seller, new_payout);
+        }
+
+        // Transfer to each seller (grouped by seller for efficiency)
+        for seller in seller_payouts.keys() {
+            let payout = seller_payouts.get(&seller).copied().unwrap_or(0);
+            token_client.transfer(
+                &env.current_contract_address(),
+                &seller,
+                &(payout as i128),
+            );
+        }
+
+        // Update accumulated fees
+        let current_fees = get_accumulated_fees(&env)?;
+        let new_fees = current_fees.checked_add(total_fees).ok_or(ContractError::Overflow)?;
+        set_accumulated_fees(&env, new_fees);
+
+        // Emit single batch event
+        events::emit_batch_trades_confirmed(&env, trade_ids.len() as u32, total_payout, total_fees);
+
+        Ok(())
+    }
 }
 
 mod token {


### PR DESCRIPTION
- Add batch_create_trades for creating multiple trades atomically
- Add batch_fund_trades with optimized single token transfer
- Add batch_confirm_trades with grouped seller payouts
- Add BatchLimitExceeded and EmptyBatch error types
- Add batch operation events (batch_cr, batch_fd, batch_cn)
- Implement gas optimizations: consolidated transfers, grouped payouts, single event emissions
- Max 100 trades per batch for optimal gas usage
closes #4 