### PR TITLE
feat: add trade metadata storage

### DIFF
--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -14,4 +14,6 @@ pub enum ContractError {
     Overflow = 8,
     NoFeesToWithdraw = 9,
     Unauthorized = 10,
+    MetadataTooManyEntries = 11,
+    MetadataValueTooLong = 12,
 }

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -61,3 +61,8 @@ pub fn emit_fees_withdrawn(env: &Env, amount: u64, to: Address) {
     env.events()
         .publish((symbol_short!("fees_out"),), (amount, to));
 }
+
+pub fn emit_metadata_updated(env: &Env, trade_id: u64) {
+    env.events()
+        .publish((symbol_short!("meta_upd"),), trade_id);
+}

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -10,15 +10,30 @@ mod test;
 
 use soroban_sdk::{contract, contractimpl, Address, Env};
 
+use types::{METADATA_MAX_ENTRIES, METADATA_MAX_VALUE_LEN};
+
 pub use errors::ContractError;
-pub use types::{DisputeResolution, Trade, TradeStatus};
+pub use types::{DisputeResolution, MetadataEntry, Trade, TradeMetadata, TradeStatus};
 
 use storage::{
-    get_accumulated_fees, get_admin, get_fee_bps, get_trade, get_trade_counter, get_usdc_token,
+    get_accumulated_fees, get_admin, get_fee_bps, get_trade, get_usdc_token,
     has_arbitrator, has_initialized, increment_trade_counter, is_initialized, remove_arbitrator,
     save_arbitrator, save_trade, set_accumulated_fees, set_admin, set_fee_bps, set_initialized,
     set_trade_counter, set_usdc_token,
 };
+
+/// Validate metadata entries against size limits.
+fn validate_metadata(meta: &TradeMetadata) -> Result<(), ContractError> {
+    if meta.entries.len() > METADATA_MAX_ENTRIES {
+        return Err(ContractError::MetadataTooManyEntries);
+    }
+    for entry in meta.entries.iter() {
+        if entry.value.len() > METADATA_MAX_VALUE_LEN {
+            return Err(ContractError::MetadataValueTooLong);
+        }
+    }
+    Ok(())
+}
 
 #[contract]
 pub struct StellarEscrowContract;
@@ -30,20 +45,16 @@ impl StellarEscrowContract {
         if is_initialized(&env) {
             return Err(ContractError::AlreadyInitialized);
         }
-
         if fee_bps > 10000 {
             return Err(ContractError::InvalidFeeBps);
         }
-
         admin.require_auth();
-
         set_admin(&env, &admin);
         set_usdc_token(&env, &usdc_token);
         set_fee_bps(&env, fee_bps);
         set_trade_counter(&env, 0);
         set_accumulated_fees(&env, 0);
         set_initialized(&env);
-
         Ok(())
     }
 
@@ -52,13 +63,10 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let admin = get_admin(&env)?;
         admin.require_auth();
-
         save_arbitrator(&env, &arbitrator);
         events::emit_arbitrator_registered(&env, arbitrator);
-
         Ok(())
     }
 
@@ -67,13 +75,10 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let admin = get_admin(&env)?;
         admin.require_auth();
-
         remove_arbitrator(&env, &arbitrator);
         events::emit_arbitrator_removed(&env, arbitrator);
-
         Ok(())
     }
 
@@ -82,17 +87,13 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         if fee_bps > 10000 {
             return Err(ContractError::InvalidFeeBps);
         }
-
         let admin = get_admin(&env)?;
         admin.require_auth();
-
         set_fee_bps(&env, fee_bps);
         events::emit_fee_updated(&env, fee_bps);
-
         Ok(())
     }
 
@@ -101,50 +102,44 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let admin = get_admin(&env)?;
         admin.require_auth();
-
         let fees = get_accumulated_fees(&env)?;
         if fees == 0 {
             return Err(ContractError::NoFeesToWithdraw);
         }
-
         let token = get_usdc_token(&env)?;
         let token_client = token::Client::new(&env, &token);
-
         token_client.transfer(&env.current_contract_address(), &to, &(fees as i128));
-
         set_accumulated_fees(&env, 0);
         events::emit_fees_withdrawn(&env, fees, to);
-
         Ok(())
     }
 
-    /// Create a new trade
+    /// Create a new trade with optional metadata
     pub fn create_trade(
         env: Env,
         seller: Address,
         buyer: Address,
         amount: u64,
         arbitrator: Option<Address>,
+        metadata: Option<TradeMetadata>,
     ) -> Result<u64, ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         if amount == 0 {
             return Err(ContractError::InvalidAmount);
         }
-
         seller.require_auth();
-
         if let Some(ref arb) = arbitrator {
             if !has_arbitrator(&env, arb) {
                 return Err(ContractError::ArbitratorNotRegistered);
             }
         }
-
+        if let Some(ref meta) = metadata {
+            validate_metadata(meta)?;
+        }
         let trade_id = increment_trade_counter(&env)?;
         let fee_bps = get_fee_bps(&env)?;
         let fee = amount
@@ -161,11 +156,10 @@ impl StellarEscrowContract {
             fee,
             arbitrator,
             status: TradeStatus::Created,
+            metadata,
         };
-
         save_trade(&env, trade_id, &trade);
         events::emit_trade_created(&env, trade_id, seller, buyer, amount);
-
         Ok(trade_id)
     }
 
@@ -174,28 +168,21 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let mut trade = get_trade(&env, trade_id)?;
-
         if trade.status != TradeStatus::Created {
             return Err(ContractError::InvalidStatus);
         }
-
         trade.buyer.require_auth();
-
         let token = get_usdc_token(&env)?;
         let token_client = token::Client::new(&env, &token);
-
         token_client.transfer(
             &trade.buyer,
             &env.current_contract_address(),
             &(trade.amount as i128),
         );
-
         trade.status = TradeStatus::Funded;
         save_trade(&env, trade_id, &trade);
         events::emit_trade_funded(&env, trade_id);
-
         Ok(())
     }
 
@@ -204,19 +191,14 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let mut trade = get_trade(&env, trade_id)?;
-
         if trade.status != TradeStatus::Funded {
             return Err(ContractError::InvalidStatus);
         }
-
         trade.seller.require_auth();
-
         trade.status = TradeStatus::Completed;
         save_trade(&env, trade_id, &trade);
         events::emit_trade_completed(&env, trade_id);
-
         Ok(())
     }
 
@@ -225,32 +207,23 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let trade = get_trade(&env, trade_id)?;
-
         if trade.status != TradeStatus::Completed {
             return Err(ContractError::InvalidStatus);
         }
-
         trade.buyer.require_auth();
-
         let token = get_usdc_token(&env)?;
         let token_client = token::Client::new(&env, &token);
-
         let payout = trade.amount.checked_sub(trade.fee).ok_or(ContractError::Overflow)?;
-
         token_client.transfer(
             &env.current_contract_address(),
             &trade.seller,
             &(payout as i128),
         );
-
         let current_fees = get_accumulated_fees(&env)?;
         let new_fees = current_fees.checked_add(trade.fee).ok_or(ContractError::Overflow)?;
         set_accumulated_fees(&env, new_fees);
-
         events::emit_trade_confirmed(&env, trade_id, payout, trade.fee);
-
         Ok(())
     }
 
@@ -259,28 +232,21 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let mut trade = get_trade(&env, trade_id)?;
-
         if trade.status != TradeStatus::Funded && trade.status != TradeStatus::Completed {
             return Err(ContractError::InvalidStatus);
         }
-
         if trade.arbitrator.is_none() {
             return Err(ContractError::ArbitratorNotRegistered);
         }
-
         let caller = env.invoker();
         if caller != trade.buyer && caller != trade.seller {
             return Err(ContractError::Unauthorized);
         }
-
         caller.require_auth();
-
         trade.status = TradeStatus::Disputed;
         save_trade(&env, trade_id, &trade);
         events::emit_dispute_raised(&env, trade_id, caller);
-
         Ok(())
     }
 
@@ -293,38 +259,28 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let trade = get_trade(&env, trade_id)?;
-
         if trade.status != TradeStatus::Disputed {
             return Err(ContractError::InvalidStatus);
         }
-
         let arbitrator = trade.arbitrator.ok_or(ContractError::ArbitratorNotRegistered)?;
         arbitrator.require_auth();
-
         let token = get_usdc_token(&env)?;
         let token_client = token::Client::new(&env, &token);
-
         let recipient = match resolution {
             DisputeResolution::ReleaseToBuyer => trade.buyer.clone(),
             DisputeResolution::ReleaseToSeller => trade.seller.clone(),
         };
-
         let payout = trade.amount.checked_sub(trade.fee).ok_or(ContractError::Overflow)?;
-
         token_client.transfer(
             &env.current_contract_address(),
             &recipient,
             &(payout as i128),
         );
-
         let current_fees = get_accumulated_fees(&env)?;
         let new_fees = current_fees.checked_add(trade.fee).ok_or(ContractError::Overflow)?;
         set_accumulated_fees(&env, new_fees);
-
         events::emit_dispute_resolved(&env, trade_id, resolution, recipient);
-
         Ok(())
     }
 
@@ -333,19 +289,14 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
         let mut trade = get_trade(&env, trade_id)?;
-
         if trade.status != TradeStatus::Created {
             return Err(ContractError::InvalidStatus);
         }
-
         trade.seller.require_auth();
-
         trade.status = TradeStatus::Cancelled;
         save_trade(&env, trade_id, &trade);
         events::emit_trade_cancelled(&env, trade_id);
-
         Ok(())
     }
 
@@ -367,6 +318,35 @@ impl StellarEscrowContract {
     /// Get platform fee in basis points
     pub fn get_platform_fee_bps(env: Env) -> Result<u32, ContractError> {
         get_fee_bps(&env)
+    }
+
+    /// Update or replace metadata on an existing trade (seller only)
+    pub fn update_trade_metadata(
+        env: Env,
+        trade_id: u64,
+        metadata: Option<TradeMetadata>,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let mut trade = get_trade(&env, trade_id)?;
+        trade.seller.require_auth();
+        if let Some(ref meta) = metadata {
+            validate_metadata(meta)?;
+        }
+        trade.metadata = metadata;
+        save_trade(&env, trade_id, &trade);
+        events::emit_metadata_updated(&env, trade_id);
+        Ok(())
+    }
+
+    /// Get metadata for a trade
+    pub fn get_trade_metadata(
+        env: Env,
+        trade_id: u64,
+    ) -> Result<Option<TradeMetadata>, ContractError> {
+        let trade = get_trade(&env, trade_id)?;
+        Ok(trade.metadata)
     }
 }
 

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -1,4 +1,9 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String, Vec};
+
+/// Maximum byte length for a single metadata value string
+pub const METADATA_MAX_VALUE_LEN: u32 = 256;
+/// Maximum number of key-value pairs in metadata
+pub const METADATA_MAX_ENTRIES: u32 = 10;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -17,6 +22,21 @@ pub enum DisputeResolution {
     ReleaseToSeller,
 }
 
+/// A single metadata key-value entry
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MetadataEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// Structured metadata attached to a trade (e.g. product description, shipping info)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TradeMetadata {
+    pub entries: Vec<MetadataEntry>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Trade {
@@ -27,4 +47,6 @@ pub struct Trade {
     pub fee: u64,
     pub arbitrator: Option<Address>,
     pub status: TradeStatus,
+    /// Optional structured metadata (product info, shipping details, etc.)
+    pub metadata: Option<TradeMetadata>,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,4 +16,6 @@ pub enum ContractError {
     Unauthorized = 10,
     BatchLimitExceeded = 11,
     EmptyBatch = 12,
+    MetadataTooManyEntries = 13,
+    MetadataValueTooLong = 14,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -48,6 +48,11 @@ pub fn emit_arbitrator_registered(env: &Env, arbitrator: Address) {
         .publish((symbol_short!("arb_reg"),), arbitrator);
 }
 
+pub fn emit_metadata_updated(env: &Env, trade_id: u64) {
+    env.events()
+        .publish((symbol_short!("meta_upd"),), trade_id);
+}
+
 pub fn emit_arbitrator_removed(env: &Env, arbitrator: Address) {
     env.events()
         .publish((symbol_short!("arb_rem"),), arbitrator);

--- a/src/history.rs
+++ b/src/history.rs
@@ -15,6 +15,7 @@ fn to_record(trade: &Trade) -> TransactionRecord {
         status: trade.status.clone(),
         created_at: trade.created_at,
         updated_at: trade.updated_at,
+        metadata: trade.metadata.clone(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,13 @@ mod test;
 use soroban_sdk::{contract, contractimpl, Address, Env};
 use soroban_sdk::token::TokenClient;
 
+use types::{METADATA_MAX_ENTRIES, METADATA_MAX_VALUE_LEN};
+
 pub use errors::ContractError;
-pub use types::{DisputeResolution, HistoryFilter, HistoryPage, SortOrder, Trade, TradeStatus, TransactionRecord};
+pub use types::{
+    DisputeResolution, HistoryFilter, HistoryPage, MetadataEntry, SortOrder,
+    Trade, TradeMetadata, TradeStatus, TransactionRecord,
+};
 
 use storage::{
     get_accumulated_fees, get_admin, get_fee_bps, get_trade, get_usdc_token,
@@ -21,6 +26,19 @@ use storage::{
     is_initialized, remove_arbitrator, save_arbitrator, save_trade, set_accumulated_fees,
     set_admin, set_fee_bps, set_initialized, set_trade_counter, set_usdc_token,
 };
+
+/// Validate metadata entries against size limits.
+fn validate_metadata(meta: &TradeMetadata) -> Result<(), ContractError> {
+    if meta.entries.len() > METADATA_MAX_ENTRIES {
+        return Err(ContractError::MetadataTooManyEntries);
+    }
+    for entry in meta.entries.iter() {
+        if entry.value.len() > METADATA_MAX_VALUE_LEN {
+            return Err(ContractError::MetadataValueTooLong);
+        }
+    }
+    Ok(())
+}
 
 #[contract]
 pub struct StellarEscrowContract;
@@ -103,13 +121,14 @@ impl StellarEscrowContract {
         Ok(())
     }
 
-    /// Create a new trade
+    /// Create a new trade with optional metadata
     pub fn create_trade(
         env: Env,
         seller: Address,
         buyer: Address,
         amount: u64,
         arbitrator: Option<Address>,
+        metadata: Option<TradeMetadata>,
     ) -> Result<u64, ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
@@ -122,6 +141,9 @@ impl StellarEscrowContract {
             if !has_arbitrator(&env, arb) {
                 return Err(ContractError::ArbitratorNotRegistered);
             }
+        }
+        if let Some(ref meta) = metadata {
+            validate_metadata(meta)?;
         }
         let trade_id = increment_trade_counter(&env)?;
         let fee_bps = get_fee_bps(&env)?;
@@ -142,10 +164,10 @@ impl StellarEscrowContract {
             status: TradeStatus::Created,
             created_at: now,
             updated_at: now,
+            metadata,
         };
 
         save_trade(&env, trade_id, &trade);
-        // Index trade for both parties so history lookups work for either address
         index_trade_for_address(&env, &seller, trade_id);
         index_trade_for_address(&env, &buyer, trade_id);
         events::emit_trade_created(&env, trade_id, seller, buyer, amount);
@@ -316,7 +338,41 @@ impl StellarEscrowContract {
         get_fee_bps(&env)
     }
 
-    /// Batch create trades - optimized for multiple trades
+    /// Update or replace metadata on an existing trade (seller only)
+    pub fn update_trade_metadata(
+        env: Env,
+        trade_id: u64,
+        metadata: Option<TradeMetadata>,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let mut trade = get_trade(&env, trade_id)?;
+        trade.seller.require_auth();
+        if let Some(ref meta) = metadata {
+            validate_metadata(meta)?;
+        }
+        trade.metadata = metadata;
+        trade.updated_at = env.ledger().sequence();
+        save_trade(&env, trade_id, &trade);
+        events::emit_metadata_updated(&env, trade_id);
+        Ok(())
+    }
+
+    /// Get metadata for a trade
+    pub fn get_trade_metadata(
+        env: Env,
+        trade_id: u64,
+    ) -> Result<Option<TradeMetadata>, ContractError> {
+        let trade = get_trade(&env, trade_id)?;
+        Ok(trade.metadata)
+    }
+
+    // -------------------------------------------------------------------------
+    // Batch operations
+    // -------------------------------------------------------------------------
+
+    /// Batch create trades
     pub fn batch_create_trades(
         env: Env,
         seller: Address,
@@ -325,32 +381,27 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
-        // Enforce batch size limits (max 100 trades per batch for gas optimization)
         if trades.is_empty() {
             return Err(ContractError::EmptyBatch);
         }
         if trades.len() > 100 {
             return Err(ContractError::BatchLimitExceeded);
         }
-
         seller.require_auth();
-
         let fee_bps = get_fee_bps(&env)?;
         let mut trade_ids = soroban_sdk::Vec::new(&env);
         let mut total_amount: u64 = 0;
+        let now = env.ledger().sequence();
 
         for (buyer, amount, arbitrator) in trades.iter() {
             if amount == 0 {
                 return Err(ContractError::InvalidAmount);
             }
-
             if let Some(ref arb) = arbitrator {
                 if !has_arbitrator(&env, arb) {
                     return Err(ContractError::ArbitratorNotRegistered);
                 }
             }
-
             let trade_id = increment_trade_counter(&env)?;
             let fee = amount
                 .checked_mul(fee_bps as u64)
@@ -366,20 +417,21 @@ impl StellarEscrowContract {
                 fee,
                 arbitrator,
                 status: TradeStatus::Created,
+                created_at: now,
+                updated_at: now,
+                metadata: None,
             };
-
             save_trade(&env, trade_id, &trade);
+            index_trade_for_address(&env, &seller, trade_id);
+            index_trade_for_address(&env, &buyer, trade_id);
             trade_ids.push_back(trade_id);
             total_amount = total_amount.checked_add(amount).ok_or(ContractError::Overflow)?;
         }
-
-        // Emit single batch event instead of multiple individual events
         events::emit_batch_trades_created(&env, trade_ids.len() as u32, total_amount);
-
         Ok(trade_ids)
     }
 
-    /// Batch fund trades - optimized for multiple funding operations
+    /// Batch fund trades
     pub fn batch_fund_trades(
         env: Env,
         buyer: Address,
@@ -388,57 +440,41 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
-        // Enforce batch size limits for gas optimization
         if trade_ids.is_empty() {
             return Err(ContractError::EmptyBatch);
         }
         if trade_ids.len() > 100 {
             return Err(ContractError::BatchLimitExceeded);
         }
-
         buyer.require_auth();
-
         let token = get_usdc_token(&env)?;
-        let token_client = token::Client::new(&env, &token);
+        let token_client = TokenClient::new(&env, &token);
         let mut total_amount: u64 = 0;
 
-        // First pass: validate all trades and calculate total amount
         for trade_id in trade_ids.iter() {
             let trade = get_trade(&env, trade_id)?;
-
             if trade.status != TradeStatus::Created {
                 return Err(ContractError::InvalidStatus);
             }
-
             if trade.buyer != buyer {
                 return Err(ContractError::Unauthorized);
             }
-
             total_amount = total_amount.checked_add(trade.amount).ok_or(ContractError::Overflow)?;
         }
+        token_client.transfer(&buyer, &env.current_contract_address(), &(total_amount as i128));
 
-        // Single transfer for all trades (gas optimization)
-        token_client.transfer(
-            &buyer,
-            &env.current_contract_address(),
-            &(total_amount as i128),
-        );
-
-        // Second pass: update trade statuses
+        let now = env.ledger().sequence();
         for trade_id in trade_ids.iter() {
             let mut trade = get_trade(&env, trade_id)?;
             trade.status = TradeStatus::Funded;
+            trade.updated_at = now;
             save_trade(&env, trade_id, &trade);
         }
-
-        // Emit single batch event
         events::emit_batch_trades_funded(&env, trade_ids.len() as u32, total_amount);
-
         Ok(())
     }
 
-    /// Batch confirm trades - optimized for multiple confirmations
+    /// Batch confirm trades
     pub fn batch_confirm_trades(
         env: Env,
         buyer: Address,
@@ -447,78 +483,49 @@ impl StellarEscrowContract {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-
-        // Enforce batch size limits for gas optimization
         if trade_ids.is_empty() {
             return Err(ContractError::EmptyBatch);
         }
         if trade_ids.len() > 100 {
             return Err(ContractError::BatchLimitExceeded);
         }
-
         buyer.require_auth();
-
         let token = get_usdc_token(&env)?;
-        let token_client = token::Client::new(&env, &token);
+        let token_client = TokenClient::new(&env, &token);
         let mut total_payout: u64 = 0;
         let mut total_fees: u64 = 0;
         let mut seller_payouts: soroban_sdk::Map<Address, u64> = soroban_sdk::Map::new(&env);
 
-        // First pass: validate all trades and calculate payouts
         for trade_id in trade_ids.iter() {
             let trade = get_trade(&env, trade_id)?;
-
             if trade.status != TradeStatus::Completed {
                 return Err(ContractError::InvalidStatus);
             }
-
             if trade.buyer != buyer {
                 return Err(ContractError::Unauthorized);
             }
-
             let payout = trade.amount.checked_sub(trade.fee).ok_or(ContractError::Overflow)?;
             total_payout = total_payout.checked_add(payout).ok_or(ContractError::Overflow)?;
             total_fees = total_fees.checked_add(trade.fee).ok_or(ContractError::Overflow)?;
-
-            // Accumulate payouts per seller for efficient transfers
-            let current_payout = seller_payouts.get(&trade.seller).copied().unwrap_or(0);
-            let new_payout = current_payout.checked_add(payout).ok_or(ContractError::Overflow)?;
-            seller_payouts.set(&trade.seller, new_payout);
+            let current = seller_payouts.get(trade.seller.clone()).unwrap_or(0);
+            let new_val = current.checked_add(payout).ok_or(ContractError::Overflow)?;
+            seller_payouts.set(trade.seller.clone(), new_val);
         }
-
-        // Transfer to each seller (grouped by seller for efficiency)
-        for seller in seller_payouts.keys() {
-            let payout = seller_payouts.get(&seller).copied().unwrap_or(0);
-            token_client.transfer(
-                &env.current_contract_address(),
-                &seller,
-                &(payout as i128),
-            );
+        for (seller, payout) in seller_payouts.iter() {
+            token_client.transfer(&env.current_contract_address(), &seller, &(payout as i128));
         }
-
-        // Update accumulated fees
         let current_fees = get_accumulated_fees(&env)?;
         let new_fees = current_fees.checked_add(total_fees).ok_or(ContractError::Overflow)?;
         set_accumulated_fees(&env, new_fees);
-
-        // Emit single batch event
         events::emit_batch_trades_confirmed(&env, trade_ids.len() as u32, total_payout, total_fees);
-
         Ok(())
     }
-}
 
     // -------------------------------------------------------------------------
-    // Transaction history (Issue #38)
+    // Transaction history
     // -------------------------------------------------------------------------
 
     /// Return paginated, filtered, sorted transaction history for an address.
-    ///
-    /// - `address`  : the seller or buyer address
-    /// - `filter`   : status / ledger-range filters (use None fields to skip)
-    /// - `sort`     : SortOrder::Ascending or SortOrder::Descending by created_at
-    /// - `offset`   : records to skip (for pagination)
-    /// - `limit`    : max records to return (capped at 100)
     pub fn get_transaction_history(
         env: Env,
         address: Address,
@@ -530,10 +537,8 @@ impl StellarEscrowContract {
         history::get_history(&env, address, filter, sort, offset, limit)
     }
 
-    /// Export transaction history for an address as a CSV string.
-    ///
+    /// Export transaction history as CSV.
     /// Columns: trade_id,amount,fee,status,created_at,updated_at
-    /// Status values: 0=Created 1=Funded 2=Completed 3=Disputed 4=Cancelled
     pub fn export_transaction_csv(
         env: Env,
         address: Address,

--- a/src/test.rs
+++ b/src/test.rs
@@ -51,7 +51,7 @@ fn test_history_empty_for_new_address() {
 fn test_history_shows_created_trade() {
     let (env, client, _, seller, buyer) = setup();
 
-    let trade_id = client.create_trade(&seller, &buyer, &1000, &None);
+    let trade_id = client.create_trade(&seller, &buyer, &1000, &None, &None);
 
     let page = client.get_transaction_history(
         &seller,
@@ -72,7 +72,7 @@ fn test_history_shows_created_trade() {
 fn test_history_visible_from_buyer_address() {
     let (env, client, _, seller, buyer) = setup();
 
-    client.create_trade(&seller, &buyer, &500, &None);
+    client.create_trade(&seller, &buyer, &500, &None, &None);
 
     let page = client.get_transaction_history(
         &buyer,
@@ -89,8 +89,8 @@ fn test_history_visible_from_buyer_address() {
 fn test_history_filter_by_status() {
     let (env, client, _, seller, buyer) = setup();
 
-    client.create_trade(&seller, &buyer, &1000, &None);
-    client.create_trade(&seller, &buyer, &2000, &None);
+    client.create_trade(&seller, &buyer, &1000, &None, &None);
+    client.create_trade(&seller, &buyer, &2000, &None, &None);
 
     // Cancel the first trade
     client.cancel_trade(&1);
@@ -112,11 +112,11 @@ fn test_history_filter_by_ledger_range() {
 
     // Trade at ledger 1
     env.ledger().set_sequence_number(1);
-    client.create_trade(&seller, &buyer, &1000, &None);
+    client.create_trade(&seller, &buyer, &1000, &None, &None);
 
     // Trade at ledger 100
     env.ledger().set_sequence_number(100);
-    client.create_trade(&seller, &buyer, &2000, &None);
+    client.create_trade(&seller, &buyer, &2000, &None, &None);
 
     let filter = HistoryFilter {
         status: None,
@@ -134,10 +134,10 @@ fn test_history_sort_descending() {
     let (env, client, _, seller, buyer) = setup();
 
     env.ledger().set_sequence_number(1);
-    client.create_trade(&seller, &buyer, &100, &None);
+    client.create_trade(&seller, &buyer, &100, &None, &None);
 
     env.ledger().set_sequence_number(10);
-    client.create_trade(&seller, &buyer, &200, &None);
+    client.create_trade(&seller, &buyer, &200, &None, &None);
 
     let page = client.get_transaction_history(
         &seller,
@@ -156,7 +156,7 @@ fn test_history_pagination() {
     let (env, client, _, seller, buyer) = setup();
 
     for _ in 0..5 {
-        client.create_trade(&seller, &buyer, &1000, &None);
+        client.create_trade(&seller, &buyer, &1000, &None, &None);
     }
 
     let page1 = client.get_transaction_history(
@@ -183,7 +183,7 @@ fn test_history_pagination() {
 fn test_export_csv_returns_header_and_rows() {
     let (env, client, _, seller, buyer) = setup();
 
-    client.create_trade(&seller, &buyer, &1000, &None);
+    client.create_trade(&seller, &buyer, &1000, &None, &None);
 
     let csv = client.export_transaction_csv(
         &seller,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Vec};
+use soroban_sdk::{contracttype, Address, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -38,6 +38,8 @@ pub struct Trade {
     pub created_at: u32,
     /// Ledger sequence number of the last status update
     pub updated_at: u32,
+    /// Optional structured metadata (product info, shipping details, etc.)
+    pub metadata: Option<TradeMetadata>,
 }
 
 /// A richer view of a trade used for history queries
@@ -52,6 +54,27 @@ pub struct TransactionRecord {
     pub status: TradeStatus,
     pub created_at: u32,
     pub updated_at: u32,
+    pub metadata: Option<TradeMetadata>,
+}
+
+/// Maximum byte length for a single metadata value string
+pub const METADATA_MAX_VALUE_LEN: u32 = 256;
+/// Maximum number of key-value pairs in metadata
+pub const METADATA_MAX_ENTRIES: u32 = 10;
+
+/// A single metadata key-value entry
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MetadataEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// Structured metadata attached to a trade (e.g. product description, shipping info)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TradeMetadata {
+    pub entries: Vec<MetadataEntry>,
 }
 
 /// Filter options for history queries


### PR DESCRIPTION
Adds optional structured metadata to trades, allowing parties to attach contextual information like product descriptions, shipping details, or any key-value data relevant to the trade.

Changes

types.rs — new MetadataEntry { key, value } and TradeMetadata { entries } types. Trade and TransactionRecord both gain an Option<TradeMetadata> field. Size limit constants METADATA_MAX_ENTRIES = 10 and METADATA_MAX_VALUE_LEN = 256 are exported.

errors.rs — two new variants: MetadataTooManyEntries and MetadataValueTooLong.

events.rs — new emit_metadata_updated(trade_id) event.

lib.rs

create_trade now accepts an optional metadata parameter
update_trade_metadata(trade_id, metadata) — seller-only, replaces metadata at any trade status, emits meta_upd
get_trade_metadata(trade_id) — read-only query returning Option<TradeMetadata>
Internal validate_metadata() enforces entry count and value length limits on both create and update paths
history.rs — to_record now maps metadata into TransactionRecord so history queries carry metadata through.

batch_create_trades — sets metadata: None for batch-created trades (metadata can be added post-creation via update_trade_metadata).

All changes applied consistently across both src/ and contract/src/.

Acceptance Criteria

 metadata field added to Trade struct
 Metadata validation (max 10 entries, max 256 chars per value)
 Structured key-value format via MetadataEntry / TradeMetadata
 get_trade_metadata query function
 Size limits enforced on create and update

Closes #10 