### PR TITLE
feat: theme system constants for dark/light mode, color, and font size preferences

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod events;
 mod history;
 mod storage;
 mod templates;
+mod theme;
 mod tiers;
 mod trade_detail;
 mod types;
@@ -20,6 +21,11 @@ use soroban_sdk::token::TokenClient;
 use types::{METADATA_MAX_ENTRIES, METADATA_MAX_VALUE_LEN};
 
 pub use errors::ContractError;
+pub use theme::{
+    FONT_LG, FONT_MD, FONT_SM,
+    PREF_FONT_SIZE, PREF_THEME_COLOR, PREF_THEME_MODE,
+    THEME_DARK, THEME_LIGHT, THEME_SYSTEM,
+};
 pub use types::{
     DisputeResolution, HistoryFilter, HistoryPage, MetadataEntry, SortOrder,
     TierConfig, Trade, TradeMetadata, TradeStatus, TradeTemplate, TemplateTerms,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,25 @@
+/// Theme preference keys — use with `set_user_preference` / `get_user_preference`.
+///
+/// All values are stored as UTF-8 strings via the existing `UserPreference` system.
+/// Clients SHOULD validate values against the constants below before storing.
+
+// ── Keys ─────────────────────────────────────────────────────────────────────
+
+/// Color mode: `"light"` | `"dark"` | `"system"`
+pub const PREF_THEME_MODE: &str = "theme.mode";
+
+/// Accent color as a hex string, e.g. `"#6366f1"`
+pub const PREF_THEME_COLOR: &str = "theme.color";
+
+/// Font size: `"sm"` | `"md"` | `"lg"`
+pub const PREF_FONT_SIZE: &str = "theme.font_size";
+
+// ── Valid values ──────────────────────────────────────────────────────────────
+
+pub const THEME_LIGHT: &str = "light";
+pub const THEME_DARK: &str = "dark";
+pub const THEME_SYSTEM: &str = "system";
+
+pub const FONT_SM: &str = "sm";
+pub const FONT_MD: &str = "md";
+pub const FONT_LG: &str = "lg";


### PR DESCRIPTION


Title: feat: theme system constants for dark/light mode, color, and font size preferences

Description:

## Summary

Implements the theme system by leveraging the existing UserPreference storage — no new contract logic needed. Adds a 
theme.rs module with canonical preference keys and valid values that clients use with the existing set_user_preference
/ get_user_preference contract functions.

## Changes

### src/theme.rs (new file)
Defines all theme preference keys and valid values:

| Constant | Value | Purpose |
|---|---|---|
| PREF_THEME_MODE | "theme.mode" | Key for color mode |
| PREF_THEME_COLOR | "theme.color" | Key for accent color (hex) |
| PREF_FONT_SIZE | "theme.font_size" | Key for font size |
| THEME_LIGHT/DARK/SYSTEM | "light"/"dark"/"system" | Valid mode values |
| FONT_SM/MD/LG | "sm"/"md"/"lg" | Valid font size values |

### src/lib.rs
- Registers mod theme
- Re-exports all theme constants for SDK consumers

## Usage



## Acceptance Criteria

| Criteria | Implementation |
|---|---|
| Theme switching | PREF_THEME_MODE key + set_user_preference |
| Dark/light modes | THEME_DARK, THEME_LIGHT, THEME_SYSTEM values |
| Color customization | PREF_THEME_COLOR key (hex string value) |
| Font size options | PREF_FONT_SIZE key + FONT_SM/MD/LG values |
| Store user preferences | Existing UserPreference persistent storage |
closes #43