### PR TITLE
feat: add trade creation TUI with form validation and preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contract", "indexer"]
+members = ["contract", "indexer", "ui"]
 
 [package]
 name = "stellar-escrow"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "stellar-escrow-ui"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "stellar-escrow-ui"
+path = "src/main.rs"
+
+[dependencies]
+ratatui = "0.26"
+crossterm = "0.27"
+anyhow = "1.0"

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1,0 +1,110 @@
+use crate::form::{Currency, TradeForm};
+
+/// Which field is currently focused in the form
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Field {
+    Seller,
+    Buyer,
+    Amount,
+    Currency,
+    Arbitrator,
+}
+
+impl Field {
+    const ORDER: &'static [Field] = &[
+        Field::Seller,
+        Field::Buyer,
+        Field::Amount,
+        Field::Currency,
+        Field::Arbitrator,
+    ];
+
+    pub fn next(self) -> Self {
+        let pos = Self::ORDER.iter().position(|f| *f == self).unwrap_or(0);
+        Self::ORDER[(pos + 1) % Self::ORDER.len()]
+    }
+
+    pub fn prev(self) -> Self {
+        let pos = Self::ORDER.iter().position(|f| *f == self).unwrap_or(0);
+        Self::ORDER[(pos + Self::ORDER.len() - 1) % Self::ORDER.len()]
+    }
+}
+
+/// Top-level screen
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Screen {
+    Form,
+    Preview,
+    Submitted,
+}
+
+pub struct App {
+    pub form: TradeForm,
+    pub focused: Field,
+    pub screen: Screen,
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self {
+            form: TradeForm::default(),
+            focused: Field::Seller,
+            screen: Screen::Form,
+            should_quit: false,
+        }
+    }
+
+    /// Handle a printable character input on the current text field.
+    pub fn type_char(&mut self, c: char) {
+        match self.focused {
+            Field::Seller => self.form.seller.push(c),
+            Field::Buyer => self.form.buyer.push(c),
+            Field::Amount => {
+                // Only allow digits and one decimal point
+                if c.is_ascii_digit() || (c == '.' && !self.form.amount.contains('.')) {
+                    self.form.amount.push(c);
+                }
+            }
+            Field::Arbitrator => self.form.arbitrator.push(c),
+            Field::Currency => {} // handled by left/right
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        match self.focused {
+            Field::Seller => { self.form.seller.pop(); }
+            Field::Buyer => { self.form.buyer.pop(); }
+            Field::Amount => { self.form.amount.pop(); }
+            Field::Arbitrator => { self.form.arbitrator.pop(); }
+            Field::Currency => {}
+        }
+    }
+
+    pub fn cycle_currency(&mut self, forward: bool) {
+        let len = Currency::ALL.len();
+        if forward {
+            self.form.currency_idx = (self.form.currency_idx + 1) % len;
+        } else {
+            self.form.currency_idx = (self.form.currency_idx + len - 1) % len;
+        }
+    }
+
+    /// Try to advance to the preview screen.
+    pub fn submit_form(&mut self) {
+        if self.form.validate() {
+            self.screen = Screen::Preview;
+        }
+    }
+
+    /// Confirm from preview — mark as submitted.
+    pub fn confirm(&mut self) {
+        self.screen = Screen::Submitted;
+    }
+
+    pub fn back(&mut self) {
+        if self.screen == Screen::Preview {
+            self.screen = Screen::Form;
+        }
+    }
+}

--- a/ui/src/form.rs
+++ b/ui/src/form.rs
@@ -1,0 +1,76 @@
+/// Supported currencies for trade amount
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Currency {
+    Usdc,
+    Xlm,
+}
+
+impl Currency {
+    pub const ALL: &'static [Currency] = &[Currency::Usdc, Currency::Xlm];
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Currency::Usdc => "USDC",
+            Currency::Xlm => "XLM",
+        }
+    }
+}
+
+/// All form fields for trade creation
+#[derive(Debug, Default)]
+pub struct TradeForm {
+    pub seller: String,
+    pub buyer: String,
+    pub amount: String,
+    pub currency_idx: usize,
+    pub arbitrator: String,
+    /// Errors keyed by field name
+    pub errors: Vec<(&'static str, String)>,
+}
+
+impl TradeForm {
+    /// Validate all fields; populates `errors` and returns true if valid.
+    pub fn validate(&mut self) -> bool {
+        self.errors.clear();
+
+        if !is_valid_stellar_address(&self.seller) {
+            self.errors.push(("seller", "Invalid Stellar address".into()));
+        }
+        if !is_valid_stellar_address(&self.buyer) {
+            self.errors.push(("buyer", "Invalid Stellar address".into()));
+        }
+        if self.seller == self.buyer && !self.seller.is_empty() {
+            self.errors.push(("buyer", "Buyer and seller must differ".into()));
+        }
+        match self.amount.trim().parse::<f64>() {
+            Ok(v) if v > 0.0 => {}
+            _ => self.errors.push(("amount", "Amount must be a positive number".into())),
+        }
+        // Arbitrator is optional; validate only if provided
+        if !self.arbitrator.trim().is_empty() && !is_valid_stellar_address(&self.arbitrator) {
+            self.errors.push(("arbitrator", "Invalid Stellar address".into()));
+        }
+
+        self.errors.is_empty()
+    }
+
+    pub fn currency(&self) -> Currency {
+        Currency::ALL[self.currency_idx]
+    }
+
+    pub fn error_for(&self, field: &str) -> Option<&str> {
+        self.errors
+            .iter()
+            .find(|(f, _)| *f == field)
+            .map(|(_, msg)| msg.as_str())
+    }
+}
+
+/// Basic Stellar address validation: starts with 'G', length 56, alphanumeric.
+fn is_valid_stellar_address(addr: &str) -> bool {
+    let addr = addr.trim();
+    addr.len() == 56
+        && addr.starts_with('G')
+        && addr.chars().all(|c| c.is_ascii_alphanumeric())
+}
+

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1,0 +1,94 @@
+mod app;
+mod form;
+mod ui;
+
+use std::io;
+
+use anyhow::Result;
+use app::{App, Field, Screen};
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, Terminal};
+
+fn main() -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run(&mut terminal);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run(terminal: &mut ratatui::Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+    let mut app = App::new();
+
+    loop {
+        terminal.draw(|f| ui::draw(f, &app))?;
+
+        if let Event::Key(key) = event::read()? {
+            match app.screen {
+                Screen::Form => handle_form_input(&mut app, key.code, key.modifiers),
+                Screen::Preview => handle_preview_input(&mut app, key.code),
+                Screen::Submitted => {
+                    if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                        app.should_quit = true;
+                    }
+                }
+            }
+        }
+
+        if app.should_quit {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_form_input(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
+    match code {
+        KeyCode::Esc => app.should_quit = true,
+        KeyCode::Tab => app.focused = app.focused.next(),
+        KeyCode::BackTab => app.focused = app.focused.prev(),
+        KeyCode::Enter => app.submit_form(),
+        KeyCode::Backspace => app.backspace(),
+        KeyCode::Left => {
+            if app.focused == Field::Currency {
+                app.cycle_currency(false);
+            }
+        }
+        KeyCode::Right => {
+            if app.focused == Field::Currency {
+                app.cycle_currency(true);
+            }
+        }
+        KeyCode::Char(c) => {
+            // Ctrl+C to quit
+            if c == 'c' && modifiers.contains(KeyModifiers::CONTROL) {
+                app.should_quit = true;
+            } else {
+                app.type_char(c);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_preview_input(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Enter => app.confirm(),
+        KeyCode::Esc => app.back(),
+        _ => {}
+    }
+}

--- a/ui/src/ui.rs
+++ b/ui/src/ui.rs
@@ -1,0 +1,219 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::app::{App, Field, Screen};
+use crate::form::Currency;
+
+pub fn draw(f: &mut Frame, app: &App) {
+    match app.screen {
+        Screen::Form => draw_form(f, app),
+        Screen::Preview => draw_preview(f, app),
+        Screen::Submitted => draw_submitted(f),
+    }
+}
+
+fn draw_form(f: &mut Frame, app: &App) {
+    let area = centered_rect(70, 80, f.size());
+
+    let block = Block::default()
+        .title(" New Trade ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    f.render_widget(Clear, area);
+    f.render_widget(block, area);
+
+    let inner = shrink(area, 2);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // seller
+            Constraint::Length(3), // buyer
+            Constraint::Length(3), // amount + currency
+            Constraint::Length(3), // arbitrator
+            Constraint::Length(1), // spacer
+            Constraint::Length(1), // errors
+            Constraint::Length(1), // spacer
+            Constraint::Length(1), // hints
+        ])
+        .split(inner);
+
+    render_input(f, chunks[0], "Seller Address", &app.form.seller, app.focused == Field::Seller, app.form.error_for("seller"));
+    render_input(f, chunks[1], "Buyer Address", &app.form.buyer, app.focused == Field::Buyer, app.form.error_for("buyer"));
+    render_amount_currency(f, chunks[2], app);
+    render_input(f, chunks[3], "Arbitrator Address (optional)", &app.form.arbitrator, app.focused == Field::Arbitrator, app.form.error_for("arbitrator"));
+
+    // Inline error summary
+    if !app.form.errors.is_empty() {
+        let msg = app.form.errors.iter().map(|(f, e)| format!("{}: {}", f, e)).collect::<Vec<_>>().join("  |  ");
+        let err = Paragraph::new(msg).style(Style::default().fg(Color::Red));
+        f.render_widget(err, chunks[5]);
+    }
+
+    let hints = Paragraph::new("Tab/Shift+Tab: navigate  ←/→: currency  Enter: preview  Esc: quit")
+        .style(Style::default().fg(Color::DarkGray));
+    f.render_widget(hints, chunks[7]);
+}
+
+fn render_input(f: &mut Frame, area: Rect, label: &str, value: &str, focused: bool, error: Option<&str>) {
+    let border_color = if error.is_some() {
+        Color::Red
+    } else if focused {
+        Color::Yellow
+    } else {
+        Color::Gray
+    };
+
+    let title = if let Some(e) = error {
+        format!(" {} — {} ", label, e)
+    } else {
+        format!(" {} ", label)
+    };
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+
+    let display = if focused {
+        format!("{}█", value)
+    } else {
+        value.to_string()
+    };
+
+    let p = Paragraph::new(display).block(block);
+    f.render_widget(p, area);
+}
+
+fn render_amount_currency(f: &mut Frame, area: Rect, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(10), Constraint::Length(12)])
+        .split(area);
+
+    render_input(f, chunks[0], "Amount", &app.form.amount, app.focused == Field::Amount, app.form.error_for("amount"));
+
+    // Currency selector
+    let border_color = if app.focused == Field::Currency { Color::Yellow } else { Color::Gray };
+    let block = Block::default()
+        .title(" Currency ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+
+    let spans: Vec<Span> = Currency::ALL.iter().enumerate().map(|(i, c)| {
+        if i == app.form.currency_idx {
+            Span::styled(format!("[{}]", c.label()), Style::default().fg(Color::Black).bg(Color::Yellow).add_modifier(Modifier::BOLD))
+        } else {
+            Span::styled(format!(" {} ", c.label()), Style::default().fg(Color::Gray))
+        }
+    }).collect();
+
+    let p = Paragraph::new(Line::from(spans)).block(block);
+    f.render_widget(p, chunks[1]);
+}
+
+fn draw_preview(f: &mut Frame, app: &App) {
+    let area = centered_rect(60, 60, f.size());
+    f.render_widget(Clear, area);
+
+    let form = &app.form;
+    let arbitrator = if form.arbitrator.trim().is_empty() {
+        "None".to_string()
+    } else {
+        truncate(&form.arbitrator, 20)
+    };
+
+    let seller_str = truncate(&form.seller, 40);
+    let buyer_str = truncate(&form.buyer, 40);
+    let amount_str = format!("{} {}", form.amount.trim(), form.currency().label());
+
+    let lines = vec![
+        Line::from(vec![Span::styled("Trade Preview", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(""),
+        labeled("Seller",     &seller_str),
+        labeled("Buyer",      &buyer_str),
+        labeled("Amount",     &amount_str),
+        labeled("Arbitrator", &arbitrator),
+        Line::from(""),
+        Line::from(vec![Span::styled("Enter: confirm  Esc: back", Style::default().fg(Color::DarkGray))]),
+    ];
+
+    let block = Block::default()
+        .title(" Confirm Trade ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Green));
+
+    let p = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+    f.render_widget(p, area);
+}
+
+fn draw_submitted(f: &mut Frame) {
+    let area = centered_rect(50, 30, f.size());
+    f.render_widget(Clear, area);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled("  Trade submitted successfully.", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  Press Esc to quit.", Style::default().fg(Color::DarkGray))]),
+    ];
+
+    let block = Block::default()
+        .title(" Done ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Green));
+
+    let p = Paragraph::new(lines).block(block);
+    f.render_widget(p, area);
+}
+
+// --- helpers ---
+
+fn labeled<'a>(key: &'a str, val: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(format!("  {:<12} ", key), Style::default().fg(Color::Gray)),
+        Span::styled(val.to_string(), Style::default().fg(Color::White)),
+    ])
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max])
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(layout[1])[1]
+}
+
+fn shrink(r: Rect, margin: u16) -> Rect {
+    Rect {
+        x: r.x + margin,
+        y: r.y + margin,
+        width: r.width.saturating_sub(margin * 2),
+        height: r.height.saturating_sub(margin * 2),
+    }
+}


### PR DESCRIPTION

Title: feat: trade creation TUI with form validation and preview

Description:

Closes #29 

Adds a terminal UI for creating new trades, built with Ratatui.

What's included:

Trade creation form with seller, buyer, amount, currency, and arbitrator fields
Stellar address validation (G-prefix, 56 chars) for buyer, seller, and optional arbitrator
Amount input restricted to valid positive numbers with USDC/XLM currency toggle
Arbitrator field (optional — skips validation if left blank)
Preview screen showing a summary before confirming
Confirmation screen on submit
New ui crate wired into the workspace
How to run:

cargo run -p stellar-escrow-ui