### PR TITLE
feat: notification service — email, SMS, push, templates & preferences

### DIFF
--- a/indexer/migrations/20260327000000_notifications.sql
+++ b/indexer/migrations/20260327000000_notifications.sql
@@ -1,0 +1,34 @@
+-- Notification preferences per user address
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    address         VARCHAR(64) PRIMARY KEY,
+    email_enabled   BOOLEAN     NOT NULL DEFAULT FALSE,
+    email_address   TEXT,
+    sms_enabled     BOOLEAN     NOT NULL DEFAULT FALSE,
+    phone_number    TEXT,
+    push_enabled    BOOLEAN     NOT NULL DEFAULT FALSE,
+    push_token      TEXT,
+    -- Granular event toggles (all on by default)
+    on_trade_created    BOOLEAN NOT NULL DEFAULT TRUE,
+    on_trade_funded     BOOLEAN NOT NULL DEFAULT TRUE,
+    on_trade_completed  BOOLEAN NOT NULL DEFAULT TRUE,
+    on_trade_confirmed  BOOLEAN NOT NULL DEFAULT TRUE,
+    on_dispute_raised   BOOLEAN NOT NULL DEFAULT TRUE,
+    on_dispute_resolved BOOLEAN NOT NULL DEFAULT TRUE,
+    on_trade_cancelled  BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Outbound notification log
+CREATE TABLE IF NOT EXISTS notification_log (
+    id          BIGSERIAL   PRIMARY KEY,
+    address     VARCHAR(64) NOT NULL,
+    channel     VARCHAR(16) NOT NULL,   -- email | sms | push
+    template_id VARCHAR(64) NOT NULL,
+    subject     TEXT,
+    body        TEXT        NOT NULL,
+    status      VARCHAR(16) NOT NULL DEFAULT 'sent',  -- sent | failed
+    error       TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notif_log_address ON notification_log (address, created_at DESC);

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -9,6 +9,8 @@ pub struct Config {
     pub stellar: StellarConfig,
     pub rate_limit: RateLimitConfig,
     pub storage: StorageConfig,
+    #[serde(default)]
+    pub notification: NotificationConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +51,23 @@ pub struct StorageConfig {
     pub base_dir: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationConfig {
+    // Email (SendGrid-compatible)
+    pub email_api_url: String,
+    pub email_api_key: String,
+    pub email_from: String,
+    // SMS (Twilio-compatible)
+    pub sms_api_url: String,
+    pub sms_account_sid: String,
+    pub sms_auth_token: String,
+    pub sms_from: String,
+    // Push (FCM v1)
+    pub push_api_url: String,
+    pub push_project_id: String,
+    pub push_server_key: String,
+}
+
 impl Config {
     pub fn load(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let contents = fs::read_to_string(path)?;
@@ -79,6 +98,18 @@ impl Default for Config {
                 blacklist: vec![],
             storage: StorageConfig {
                 base_dir: "./uploads".to_string(),
+            },
+            notification: NotificationConfig {
+                email_api_url: "https://api.sendgrid.com".to_string(),
+                email_api_key: String::new(),
+                email_from: "noreply@stellarescrow.io".to_string(),
+                sms_api_url: "https://api.twilio.com".to_string(),
+                sms_account_sid: String::new(),
+                sms_auth_token: String::new(),
+                sms_from: String::new(),
+                push_api_url: "https://fcm.googleapis.com".to_string(),
+                push_project_id: String::new(),
+                push_server_key: String::new(),
             },
         }
     }

--- a/indexer/src/database.rs
+++ b/indexer/src/database.rs
@@ -673,4 +673,143 @@ impl Database {
 
         Ok(())
     }
+
+    // =========================================================================
+    // Notification Operations
+    // =========================================================================
+
+    pub async fn get_notification_preferences(
+        &self,
+        address: &str,
+    ) -> Result<Option<crate::models::NotificationPreferences>, AppError> {
+        let row = sqlx::query_as::<_, crate::models::NotificationPreferences>(
+            "SELECT * FROM notification_preferences WHERE address = $1",
+        )
+        .bind(address)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn upsert_notification_preferences(
+        &self,
+        address: &str,
+        upd: &crate::models::UpdateNotificationPreferences,
+    ) -> Result<crate::models::NotificationPreferences, AppError> {
+        // Fetch existing or use defaults, then apply partial update
+        let existing = self.get_notification_preferences(address).await?;
+        let base = existing.unwrap_or_else(|| crate::models::NotificationPreferences {
+            address: address.to_string(),
+            email_enabled: false,
+            email_address: None,
+            sms_enabled: false,
+            phone_number: None,
+            push_enabled: false,
+            push_token: None,
+            on_trade_created: true,
+            on_trade_funded: true,
+            on_trade_completed: true,
+            on_trade_confirmed: true,
+            on_dispute_raised: true,
+            on_dispute_resolved: true,
+            on_trade_cancelled: true,
+            updated_at: chrono::Utc::now(),
+        });
+
+        let row = sqlx::query_as::<_, crate::models::NotificationPreferences>(
+            r#"
+            INSERT INTO notification_preferences
+                (address, email_enabled, email_address, sms_enabled, phone_number,
+                 push_enabled, push_token,
+                 on_trade_created, on_trade_funded, on_trade_completed, on_trade_confirmed,
+                 on_dispute_raised, on_dispute_resolved, on_trade_cancelled, updated_at)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,NOW())
+            ON CONFLICT (address) DO UPDATE SET
+                email_enabled   = EXCLUDED.email_enabled,
+                email_address   = EXCLUDED.email_address,
+                sms_enabled     = EXCLUDED.sms_enabled,
+                phone_number    = EXCLUDED.phone_number,
+                push_enabled    = EXCLUDED.push_enabled,
+                push_token      = EXCLUDED.push_token,
+                on_trade_created    = EXCLUDED.on_trade_created,
+                on_trade_funded     = EXCLUDED.on_trade_funded,
+                on_trade_completed  = EXCLUDED.on_trade_completed,
+                on_trade_confirmed  = EXCLUDED.on_trade_confirmed,
+                on_dispute_raised   = EXCLUDED.on_dispute_raised,
+                on_dispute_resolved = EXCLUDED.on_dispute_resolved,
+                on_trade_cancelled  = EXCLUDED.on_trade_cancelled,
+                updated_at = NOW()
+            RETURNING *
+            "#,
+        )
+        .bind(address)
+        .bind(upd.email_enabled.unwrap_or(base.email_enabled))
+        .bind(upd.email_address.as_ref().or(base.email_address.as_ref()))
+        .bind(upd.sms_enabled.unwrap_or(base.sms_enabled))
+        .bind(upd.phone_number.as_ref().or(base.phone_number.as_ref()))
+        .bind(upd.push_enabled.unwrap_or(base.push_enabled))
+        .bind(upd.push_token.as_ref().or(base.push_token.as_ref()))
+        .bind(upd.on_trade_created.unwrap_or(base.on_trade_created))
+        .bind(upd.on_trade_funded.unwrap_or(base.on_trade_funded))
+        .bind(upd.on_trade_completed.unwrap_or(base.on_trade_completed))
+        .bind(upd.on_trade_confirmed.unwrap_or(base.on_trade_confirmed))
+        .bind(upd.on_dispute_raised.unwrap_or(base.on_dispute_raised))
+        .bind(upd.on_dispute_resolved.unwrap_or(base.on_dispute_resolved))
+        .bind(upd.on_trade_cancelled.unwrap_or(base.on_trade_cancelled))
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn log_notification(
+        &self,
+        address: &str,
+        channel: &str,
+        template_id: &str,
+        subject: Option<&str>,
+        body: &str,
+        result: Result<(), String>,
+    ) {
+        let (status, error) = match result {
+            Ok(()) => ("sent", None),
+            Err(e) => ("failed", Some(e)),
+        };
+        let _ = sqlx::query(
+            r#"
+            INSERT INTO notification_log (address, channel, template_id, subject, body, status, error)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#,
+        )
+        .bind(address)
+        .bind(channel)
+        .bind(template_id)
+        .bind(subject)
+        .bind(body)
+        .bind(status)
+        .bind(error)
+        .execute(&self.pool)
+        .await;
+    }
+
+    pub async fn get_notification_log(
+        &self,
+        address: &str,
+        limit: i64,
+    ) -> Result<Vec<crate::models::NotificationLogEntry>, AppError> {
+        let rows = sqlx::query_as::<_, crate::models::NotificationLogEntry>(
+            r#"
+            SELECT id, address, channel, template_id, subject, body, status, error, created_at
+            FROM notification_log
+            WHERE address = $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(address)
+        .bind(limit.clamp(1, 200))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
 }

--- a/indexer/src/error.rs
+++ b/indexer/src/error.rs
@@ -26,6 +26,9 @@ pub enum AppError {
     #[error("Event not found")]
     EventNotFound,
 
+    #[error("Not found: {0}")]
+    NotFound(String),
+
     #[error("Internal server error")]
     InternalServerError,
 
@@ -78,6 +81,7 @@ impl IntoResponse for AppError {
             AppError::HttpClient(_) => (StatusCode::INTERNAL_SERVER_ERROR, "NETWORK_ERROR", "Network error"),
             AppError::InvalidEventData(_) => (StatusCode::BAD_REQUEST, "INVALID_EVENT_DATA", "Invalid event data"),
             AppError::EventNotFound => (StatusCode::NOT_FOUND, "EVENT_NOT_FOUND", "Event not found"),
+            AppError::NotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND", "Resource not found"),
             AppError::InternalServerError => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "Internal server error"),
         };
 

--- a/indexer/src/event_monitor.rs
+++ b/indexer/src/event_monitor.rs
@@ -60,6 +60,7 @@ pub struct EventMonitor {
     client: Client,
     last_ledger: Option<i64>,
     fraud_service: Arc<FraudDetectionService>,
+    notification_service: Arc<crate::notification_service::NotificationService>,
 }
 
 impl EventMonitor {
@@ -68,12 +69,14 @@ impl EventMonitor {
         database: Arc<Database>,
         ws_manager: Arc<WebSocketManager>,
         fraud_service: Arc<FraudDetectionService>,
+        notification_service: Arc<crate::notification_service::NotificationService>,
     ) -> Self {
         Self {
             config,
             database,
             ws_manager,
             fraud_service,
+            notification_service,
             client: Client::new(),
             last_ledger: config.start_ledger.map(|l| l as i64),
         }
@@ -155,6 +158,9 @@ impl EventMonitor {
                         }).await;
                     }
                 }
+
+                // Dispatch notifications to trade parties
+                self.notification_service.process_event(&event).await;
             }
         }
 

--- a/indexer/src/handlers.rs
+++ b/indexer/src/handlers.rs
@@ -57,6 +57,9 @@ pub async fn api_index() -> Json<serde_json::Value> {
             "audit_purge":     "DELETE /audit/purge  {older_than_days?}"
             "fraud_alerts":    "GET  /fraud/alerts",
             "fraud_review":    "POST /fraud/review  {trade_id, status, reviewer, notes}",
+            "notif_prefs_get": "GET  /notifications/preferences/:address",
+            "notif_prefs_put": "PUT  /notifications/preferences/:address  {email_enabled, email_address, sms_enabled, phone_number, push_enabled, push_token, on_*}",
+            "notif_log":       "GET  /notifications/log/:address?limit=",
             "help":            "GET  /help"
         }
     }))
@@ -330,6 +333,7 @@ pub struct AppState {
     pub ws_manager: Arc<WebSocketManager>,
     pub health: HealthState,
     pub fraud_service: Arc<FraudDetectionService>,
+    pub notification_service: Arc<NotificationService>,
 }
 
 // =============================================================================
@@ -384,4 +388,38 @@ pub async fn purge_audit_logs(
     let days = body.older_than_days.unwrap_or(90).clamp(1, 365);
     let deleted = state.database.purge_old_audit_logs(days).await?;
     Ok(Json(RetentionResponse { deleted, older_than_days: days }))
+}
+
+// =============================================================================
+// Notification Handlers
+// =============================================================================
+
+/// GET /notifications/preferences/:address
+pub async fn get_notification_preferences(
+    Path(address): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Json<crate::models::NotificationPreferences>, AppError> {
+    let prefs = state.database.get_notification_preferences(&address).await?
+        .ok_or_else(|| AppError::NotFound("preferences not found".into()))?;
+    Ok(Json(prefs))
+}
+
+/// PUT /notifications/preferences/:address
+pub async fn upsert_notification_preferences(
+    Path(address): Path<String>,
+    State(state): State<AppState>,
+    Json(body): Json<crate::models::UpdateNotificationPreferences>,
+) -> Result<Json<crate::models::NotificationPreferences>, AppError> {
+    let prefs = state.database.upsert_notification_preferences(&address, &body).await?;
+    Ok(Json(prefs))
+}
+
+/// GET /notifications/log/:address
+pub async fn get_notification_log(
+    Path(address): Path<String>,
+    Query(params): Query<crate::models::HistoryQuery>,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<crate::models::NotificationLogEntry>>, AppError> {
+    let entries = state.database.get_notification_log(&address, params.limit.unwrap_or(50)).await?;
+    Ok(Json(entries))
 }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -31,6 +31,7 @@ mod rate_limit_handlers;
 mod storage;
 mod websocket;
 mod fraud_service;
+mod notification_service;
 
 #[cfg(test)]
 mod test;
@@ -50,6 +51,7 @@ use help::{
     get_contact, get_docs, get_faqs, get_tutorial_by_id, get_tutorials, help_index, search_help,
 };
 use fraud_service::FraudDetectionService;
+use notification_service::NotificationService;
 
 #[derive(Parser)]
 #[command(name = "stellar-escrow-indexer")]
@@ -107,12 +109,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize Fraud Detection Service
     let fraud_service = Arc::new(FraudDetectionService::new(database.clone()).await);
 
+    // Initialize Notification Service
+    let notification_service = Arc::new(NotificationService::new(
+        database.clone(),
+        config.notification.clone(),
+    ));
+
     // Initialize event monitor
     let event_monitor = EventMonitor::new(
         config.stellar.clone(),
         database.clone(),
         ws_manager.clone(),
         fraud_service.clone(),
+        notification_service.clone(),
     );
 
     // Start event monitoring in background
@@ -160,6 +169,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/search/history", get(search_history))
         .route("/fraud/alerts", get(get_fraud_alerts))
         .route("/fraud/review", post(update_fraud_review))
+        // Notifications
+        .route("/notifications/preferences/:address", get(get_notification_preferences).put(upsert_notification_preferences))
+        .route("/notifications/log/:address", get(get_notification_log))
         .route("/ws", get(ws_handler))
         // Help center
         .route("/help", get(help_index))
@@ -179,6 +191,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             database,
             ws_manager,
             health: health_state,
+            fraud_service,
+            notification_service,
         })
         .merge(admin_router)
         .layer(middleware::from_fn_with_state(

--- a/indexer/src/models.rs
+++ b/indexer/src/models.rs
@@ -397,3 +397,57 @@ pub struct RetentionResponse {
     pub deleted: u64,
     pub older_than_days: i64,
 }
+
+// =============================================================================
+// Notification Models
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct NotificationPreferences {
+    pub address: String,
+    pub email_enabled: bool,
+    pub email_address: Option<String>,
+    pub sms_enabled: bool,
+    pub phone_number: Option<String>,
+    pub push_enabled: bool,
+    pub push_token: Option<String>,
+    pub on_trade_created: bool,
+    pub on_trade_funded: bool,
+    pub on_trade_completed: bool,
+    pub on_trade_confirmed: bool,
+    pub on_dispute_raised: bool,
+    pub on_dispute_resolved: bool,
+    pub on_trade_cancelled: bool,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Upsert payload — all fields optional so callers only send what they want to change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateNotificationPreferences {
+    pub email_enabled: Option<bool>,
+    pub email_address: Option<String>,
+    pub sms_enabled: Option<bool>,
+    pub phone_number: Option<String>,
+    pub push_enabled: Option<bool>,
+    pub push_token: Option<String>,
+    pub on_trade_created: Option<bool>,
+    pub on_trade_funded: Option<bool>,
+    pub on_trade_completed: Option<bool>,
+    pub on_trade_confirmed: Option<bool>,
+    pub on_dispute_raised: Option<bool>,
+    pub on_dispute_resolved: Option<bool>,
+    pub on_trade_cancelled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct NotificationLogEntry {
+    pub id: i64,
+    pub address: String,
+    pub channel: String,
+    pub template_id: String,
+    pub subject: Option<String>,
+    pub body: String,
+    pub status: String,
+    pub error: Option<String>,
+    pub created_at: DateTime<Utc>,
+}

--- a/indexer/src/notification_service/channels.rs
+++ b/indexer/src/notification_service/channels.rs
@@ -1,0 +1,105 @@
+use reqwest::Client;
+use serde_json::json;
+use tracing::{error, info};
+
+use crate::config::NotificationConfig;
+
+/// Thin wrappers around external provider APIs.
+/// Each function logs on failure but does NOT propagate — notifications are
+/// best-effort and must never crash the main service.
+
+pub async fn send_email(
+    cfg: &NotificationConfig,
+    to: &str,
+    subject: &str,
+    body: &str,
+) -> Result<(), String> {
+    let client = Client::new();
+    // SendGrid-compatible POST /v3/mail/send
+    let payload = json!({
+        "personalizations": [{ "to": [{ "email": to }] }],
+        "from": { "email": cfg.email_from },
+        "subject": subject,
+        "content": [{ "type": "text/plain", "value": body }]
+    });
+
+    let res = client
+        .post(format!("{}/v3/mail/send", cfg.email_api_url))
+        .bearer_auth(&cfg.email_api_key)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if res.status().is_success() {
+        info!("Email sent to {}", to);
+        Ok(())
+    } else {
+        let msg = format!("Email API error {}: {}", res.status(), res.text().await.unwrap_or_default());
+        error!("{}", msg);
+        Err(msg)
+    }
+}
+
+pub async fn send_sms(
+    cfg: &NotificationConfig,
+    to: &str,
+    body: &str,
+) -> Result<(), String> {
+    let client = Client::new();
+    // Twilio-compatible POST /2010-04-01/Accounts/{sid}/Messages.json
+    let url = format!(
+        "{}/2010-04-01/Accounts/{}/Messages.json",
+        cfg.sms_api_url, cfg.sms_account_sid
+    );
+
+    let res = client
+        .post(&url)
+        .basic_auth(&cfg.sms_account_sid, Some(&cfg.sms_auth_token))
+        .form(&[("From", cfg.sms_from.as_str()), ("To", to), ("Body", body)])
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if res.status().is_success() {
+        info!("SMS sent to {}", to);
+        Ok(())
+    } else {
+        let msg = format!("SMS API error {}: {}", res.status(), res.text().await.unwrap_or_default());
+        error!("{}", msg);
+        Err(msg)
+    }
+}
+
+pub async fn send_push(
+    cfg: &NotificationConfig,
+    token: &str,
+    title: &str,
+    body: &str,
+) -> Result<(), String> {
+    let client = Client::new();
+    // FCM v1 HTTP API
+    let payload = json!({
+        "message": {
+            "token": token,
+            "notification": { "title": title, "body": body }
+        }
+    });
+
+    let res = client
+        .post(format!("{}/v1/projects/{}/messages:send", cfg.push_api_url, cfg.push_project_id))
+        .bearer_auth(&cfg.push_server_key)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if res.status().is_success() {
+        info!("Push sent to token {}", &token[..8]);
+        Ok(())
+    } else {
+        let msg = format!("Push API error {}: {}", res.status(), res.text().await.unwrap_or_default());
+        error!("{}", msg);
+        Err(msg)
+    }
+}

--- a/indexer/src/notification_service/mod.rs
+++ b/indexer/src/notification_service/mod.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::config::NotificationConfig;
+use crate::database::Database;
+use crate::models::Event;
+
+mod channels;
+pub mod templates;
+
+use templates::TemplateId;
+
+pub struct NotificationService {
+    db: Arc<Database>,
+    cfg: NotificationConfig,
+}
+
+impl NotificationService {
+    pub fn new(db: Arc<Database>, cfg: NotificationConfig) -> Self {
+        Self { db, cfg }
+    }
+
+    /// Called by the event monitor for every new contract event.
+    pub async fn process_event(&self, event: &Event) {
+        let Some(template_id) = TemplateId::from_event_type(&event.event_type) else {
+            return;
+        };
+
+        // Build template variables from event data
+        let vars = event_vars(&event.data);
+
+        // Fetch addresses that are parties to this trade
+        let addresses = trade_addresses(&event.data);
+
+        for address in addresses {
+            let Ok(Some(prefs)) = self.db.get_notification_preferences(&address).await else {
+                continue;
+            };
+
+            // Check per-event toggle
+            if !prefs_allow(&prefs, &template_id) {
+                continue;
+            }
+
+            let tmpl = templates::get(&template_id);
+            let (subject, body) = templates::render(&tmpl, &vars);
+
+            if prefs.email_enabled {
+                if let Some(ref email) = prefs.email_address {
+                    let result = channels::send_email(&self.cfg, email, &subject, &body).await;
+                    self.db.log_notification(&address, "email", template_id.as_str(), Some(&subject), &body, result).await;
+                }
+            }
+
+            if prefs.sms_enabled {
+                if let Some(ref phone) = prefs.phone_number {
+                    let result = channels::send_sms(&self.cfg, phone, &body).await;
+                    self.db.log_notification(&address, "sms", template_id.as_str(), None, &body, result).await;
+                }
+            }
+
+            if prefs.push_enabled {
+                if let Some(ref token) = prefs.push_token {
+                    let result = channels::send_push(&self.cfg, token, &subject, &body).await;
+                    self.db.log_notification(&address, "push", template_id.as_str(), Some(&subject), &body, result).await;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn event_vars(data: &serde_json::Value) -> HashMap<&'static str, String> {
+    let mut m = HashMap::new();
+    let keys = ["trade_id", "seller", "buyer", "amount", "payout", "fee", "raised_by", "resolution", "recipient"];
+    for k in keys {
+        if let Some(v) = data.get(k) {
+            m.insert(k, v.as_str().map(|s| s.to_string()).unwrap_or_else(|| v.to_string()));
+        }
+    }
+    m
+}
+
+fn trade_addresses(data: &serde_json::Value) -> Vec<String> {
+    let mut addrs = Vec::new();
+    for key in ["seller", "buyer", "raised_by", "recipient"] {
+        if let Some(v) = data.get(key).and_then(|v| v.as_str()) {
+            if !v.is_empty() && !addrs.contains(&v.to_string()) {
+                addrs.push(v.to_string());
+            }
+        }
+    }
+    addrs
+}
+
+fn prefs_allow(prefs: &crate::models::NotificationPreferences, id: &TemplateId) -> bool {
+    match id {
+        TemplateId::TradeCreated    => prefs.on_trade_created,
+        TemplateId::TradeFunded     => prefs.on_trade_funded,
+        TemplateId::TradeCompleted  => prefs.on_trade_completed,
+        TemplateId::TradeConfirmed  => prefs.on_trade_confirmed,
+        TemplateId::DisputeRaised   => prefs.on_dispute_raised,
+        TemplateId::DisputeResolved => prefs.on_dispute_resolved,
+        TemplateId::TradeCancelled  => prefs.on_trade_cancelled,
+    }
+}

--- a/indexer/src/notification_service/templates.rs
+++ b/indexer/src/notification_service/templates.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+
+/// All notification template IDs used by the service.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TemplateId {
+    TradeCreated,
+    TradeFunded,
+    TradeCompleted,
+    TradeConfirmed,
+    DisputeRaised,
+    DisputeResolved,
+    TradeCancelled,
+}
+
+impl TemplateId {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TemplateId::TradeCreated    => "trade_created",
+            TemplateId::TradeFunded     => "trade_funded",
+            TemplateId::TradeCompleted  => "trade_completed",
+            TemplateId::TradeConfirmed  => "trade_confirmed",
+            TemplateId::DisputeRaised   => "dispute_raised",
+            TemplateId::DisputeResolved => "dispute_resolved",
+            TemplateId::TradeCancelled  => "trade_cancelled",
+        }
+    }
+
+    pub fn from_event_type(event_type: &str) -> Option<Self> {
+        match event_type {
+            "trade_created"    => Some(TemplateId::TradeCreated),
+            "trade_funded"     => Some(TemplateId::TradeFunded),
+            "trade_completed"  => Some(TemplateId::TradeCompleted),
+            "trade_confirmed"  => Some(TemplateId::TradeConfirmed),
+            "dispute_raised"   => Some(TemplateId::DisputeRaised),
+            "dispute_resolved" => Some(TemplateId::DisputeResolved),
+            "trade_cancelled"  => Some(TemplateId::TradeCancelled),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Template {
+    pub subject: &'static str,
+    pub body: &'static str, // supports {{trade_id}}, {{address}} placeholders
+}
+
+/// Render a template by substituting `{{key}}` placeholders.
+pub fn render(template: &Template, vars: &HashMap<&str, String>) -> (String, String) {
+    let mut subject = template.subject.to_string();
+    let mut body = template.body.to_string();
+    for (k, v) in vars {
+        let placeholder = format!("{{{{{}}}}}", k);
+        subject = subject.replace(&placeholder, v);
+        body = body.replace(&placeholder, v);
+    }
+    (subject, body)
+}
+
+pub fn get(id: &TemplateId) -> Template {
+    match id {
+        TemplateId::TradeCreated => Template {
+            subject: "New trade #{{trade_id}} created",
+            body: "A new escrow trade #{{trade_id}} has been created. Seller: {{seller}}, Buyer: {{buyer}}, Amount: {{amount}} USDC.",
+        },
+        TemplateId::TradeFunded => Template {
+            subject: "Trade #{{trade_id}} funded",
+            body: "Trade #{{trade_id}} has been funded by the buyer. The escrow is now active.",
+        },
+        TemplateId::TradeCompleted => Template {
+            subject: "Trade #{{trade_id}} marked complete",
+            body: "The seller has marked trade #{{trade_id}} as complete. Please confirm receipt to release funds.",
+        },
+        TemplateId::TradeConfirmed => Template {
+            subject: "Trade #{{trade_id}} settled",
+            body: "Trade #{{trade_id}} has been confirmed and settled. Payout: {{payout}} USDC, Fee: {{fee}} USDC.",
+        },
+        TemplateId::DisputeRaised => Template {
+            subject: "Dispute raised on trade #{{trade_id}}",
+            body: "A dispute has been raised on trade #{{trade_id}} by {{raised_by}}. An arbitrator will review the case.",
+        },
+        TemplateId::DisputeResolved => Template {
+            subject: "Dispute resolved on trade #{{trade_id}}",
+            body: "The dispute on trade #{{trade_id}} has been resolved. Resolution: {{resolution}}. Recipient: {{recipient}}.",
+        },
+        TemplateId::TradeCancelled => Template {
+            subject: "Trade #{{trade_id}} cancelled",
+            body: "Trade #{{trade_id}} has been cancelled.",
+        },
+    }
+}


### PR DESCRIPTION
- NotificationService module dispatched on every contract event
- Email channel via SendGrid-compatible API (POST /v3/mail/send)
- SMS channel via Twilio-compatible API (Messages.json)
- Push channel via FCM v1 API (messages:send)
- 7 notification templates with {{placeholder}} rendering: trade_created, trade_funded, trade_completed, trade_confirmed, dispute_raised, dispute_resolved, trade_cancelled
- NotificationPreferences model with per-channel and per-event toggles
- DB: notification_preferences table (upsert) + notification_log table
- Migration: 20260327000000_notifications.sql
- REST API: GET  /notifications/preferences/:address PUT  /notifications/preferences/:address GET  /notifications/log/:address?limit=
- NotificationConfig added to Config with sensible defaults
- EventMonitor now calls notification_service.process_event() after fraud detection on every indexed event
- Notifications are best-effort: failures are logged, never crash the service

Closes #65 