### PR TITLE
feat: add advanced query functions (issue #15)

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -4,6 +4,7 @@ mod errors;
 mod events;
 mod governance;
 mod privacy;
+mod queries;
 mod storage;
 mod subscription;
 mod templates;
@@ -24,6 +25,7 @@ pub use types::{
     Subscription, SubscriptionTier, TierConfig, TemplateTerms, TemplateVersion,
     Trade, TradeMetadata, TradePrivacy, TradeStatus, TradeTemplate, UserTier, UserTierInfo,
 };
+pub use queries::{PageParams, SortDirection, TradeFilter, TradeSortField, TradeStats};
 
 use storage::{
     get_accumulated_fees, get_admin, get_fee_bps, get_trade, get_usdc_token,
@@ -587,6 +589,32 @@ impl StellarEscrowContract {
     /// Get platform fee in basis points
     pub fn get_platform_fee_bps(env: Env) -> Result<u32, ContractError> {
         get_fee_bps(&env)
+    }
+
+    // -------------------------------------------------------------------------
+    // Advanced Query Functions
+    // -------------------------------------------------------------------------
+
+    /// Filter, sort, and paginate trades.
+    ///
+    /// - `filter`: optional criteria (status, participant, amount range, id range)
+    /// - `page`: pagination + sort options (offset, limit ≤ 100, sort_by, direction)
+    pub fn query_trades(
+        env: Env,
+        filter: queries::TradeFilter,
+        page: queries::PageParams,
+    ) -> Result<soroban_sdk::Vec<Trade>, ContractError> {
+        require_initialized(&env)?;
+        queries::query_trades(&env, filter, page)
+    }
+
+    /// Aggregate statistics (count, volume, fees, min/max amount) over filtered trades.
+    pub fn aggregate_trades(
+        env: Env,
+        filter: queries::TradeFilter,
+    ) -> Result<queries::TradeStats, ContractError> {
+        require_initialized(&env)?;
+        queries::aggregate_trades(&env, filter)
     }
 
     // -------------------------------------------------------------------------

--- a/contract/src/queries.rs
+++ b/contract/src/queries.rs
@@ -1,0 +1,197 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+use crate::errors::ContractError;
+use crate::storage::{get_trade, get_trade_counter};
+use crate::types::{Trade, TradeStatus};
+
+// ---------------------------------------------------------------------------
+// Query parameter types
+// ---------------------------------------------------------------------------
+
+/// Sort field for trade queries
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TradeSortField {
+    Id,
+    Amount,
+}
+
+/// Sort direction
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+/// Filter criteria for trade queries (all fields are optional)
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TradeFilter {
+    /// Only return trades with this status
+    pub status: Option<TradeStatus>,
+    /// Only return trades involving this address (as buyer or seller)
+    pub participant: Option<Address>,
+    /// Minimum trade amount (inclusive)
+    pub min_amount: Option<u64>,
+    /// Maximum trade amount (inclusive)
+    pub max_amount: Option<u64>,
+    /// Only return trades with IDs >= this value (useful for time-range proxies)
+    pub from_trade_id: Option<u64>,
+    /// Only return trades with IDs <= this value
+    pub to_trade_id: Option<u64>,
+}
+
+/// Pagination parameters
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PageParams {
+    /// Number of results to skip
+    pub offset: u64,
+    /// Maximum number of results to return (capped at 100)
+    pub limit: u64,
+    /// Field to sort by
+    pub sort_by: TradeSortField,
+    /// Sort direction
+    pub direction: SortDirection,
+}
+
+/// Aggregated statistics over a set of trades
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TradeStats {
+    pub total_count: u64,
+    pub total_volume: u64,
+    pub total_fees: u64,
+    pub min_amount: u64,
+    pub max_amount: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn matches_filter(trade: &Trade, filter: &TradeFilter) -> bool {
+    if let Some(ref status) = filter.status {
+        if &trade.status != status {
+            return false;
+        }
+    }
+    if let Some(ref participant) = filter.participant {
+        if &trade.buyer != participant && &trade.seller != participant {
+            return false;
+        }
+    }
+    if let Some(min) = filter.min_amount {
+        if trade.amount < min {
+            return false;
+        }
+    }
+    if let Some(max) = filter.max_amount {
+        if trade.amount > max {
+            return false;
+        }
+    }
+    if let Some(from) = filter.from_trade_id {
+        if trade.id < from {
+            return false;
+        }
+    }
+    if let Some(to) = filter.to_trade_id {
+        if trade.id > to {
+            return false;
+        }
+    }
+    true
+}
+
+/// Collect all trades matching `filter`, then apply pagination + sorting.
+/// Returns at most `page.limit` (capped at 100) trades.
+pub fn query_trades(
+    env: &Env,
+    filter: TradeFilter,
+    page: PageParams,
+) -> Result<Vec<Trade>, ContractError> {
+    let total = get_trade_counter(env).unwrap_or(0);
+    let limit = page.limit.min(100);
+
+    // Collect matching trades into a fixed-capacity vec
+    let mut matched: Vec<Trade> = Vec::new(env);
+    for id in 1..=total {
+        if let Ok(trade) = get_trade(env, id) {
+            if matches_filter(&trade, &filter) {
+                matched.push_back(trade);
+            }
+        }
+    }
+
+    // Sort in-place using insertion sort (no alloc, no std)
+    let len = matched.len();
+    for i in 1..len {
+        let mut j = i;
+        while j > 0 {
+            let a = matched.get(j - 1).unwrap();
+            let b = matched.get(j).unwrap();
+            let swap = match page.sort_by {
+                TradeSortField::Id => match page.direction {
+                    SortDirection::Asc => a.id > b.id,
+                    SortDirection::Desc => a.id < b.id,
+                },
+                TradeSortField::Amount => match page.direction {
+                    SortDirection::Asc => a.amount > b.amount,
+                    SortDirection::Desc => a.amount < b.amount,
+                },
+            };
+            if swap {
+                matched.set(j - 1, b);
+                matched.set(j, a);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Apply offset + limit
+    let mut result: Vec<Trade> = Vec::new(env);
+    let start = page.offset.min(matched.len() as u64) as u32;
+    let end = (start as u64 + limit).min(matched.len() as u64) as u32;
+    for i in start..end {
+        result.push_back(matched.get(i).unwrap());
+    }
+    Ok(result)
+}
+
+/// Compute aggregate statistics over all trades matching `filter`.
+pub fn aggregate_trades(env: &Env, filter: TradeFilter) -> Result<TradeStats, ContractError> {
+    let total = get_trade_counter(env).unwrap_or(0);
+    let mut count: u64 = 0;
+    let mut volume: u64 = 0;
+    let mut fees: u64 = 0;
+    let mut min_amount: u64 = u64::MAX;
+    let mut max_amount: u64 = 0;
+
+    for id in 1..=total {
+        if let Ok(trade) = get_trade(env, id) {
+            if matches_filter(&trade, &filter) {
+                count += 1;
+                volume = volume.saturating_add(trade.amount);
+                fees = fees.saturating_add(trade.fee);
+                if trade.amount < min_amount {
+                    min_amount = trade.amount;
+                }
+                if trade.amount > max_amount {
+                    max_amount = trade.amount;
+                }
+            }
+        }
+    }
+
+    Ok(TradeStats {
+        total_count: count,
+        total_volume: volume,
+        total_fees: fees,
+        min_amount: if count == 0 { 0 } else { min_amount },
+        max_amount,
+    })
+}


### PR DESCRIPTION

Description:

Closes #15

Adds contract/src/queries.rs with two new contract entry points for filtering and aggregating trades.

New functions:
- query_trades(filter, page) — filter by status, participant, amount range, or trade ID range; sort by Id or Amount (asc/desc); paginate with offset/limit
(capped at 100)
- aggregate_trades(filter) — returns count, total volume, total fees, min/max amount over matching trades

New types: TradeFilter, PageParams, TradeSortField, SortDirection, TradeStats

Notes:
- Scans 1..=trade_counter since Soroban has no native storage iteration
- from_trade_id/to_trade_id act as a time-range proxy (IDs are monotonically increasing)
- Limit hard-capped at 100 to stay within compute budget