### PR TITLE
feat: React Frontend Foundation (Issue #27)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>StellarEscrow</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@stellar-escrow/app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@stellar-escrow/components": "*",
+    "@stellar-escrow/state": "*",
+    "@reduxjs/toolkit": "^1.9.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.3",
+    "react-router-dom": "^6.21.0",
+    "redux-persist": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.2",
+    "vite": "^5.0.8"
+  }
+}

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,0 +1,52 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #f5f5f5;
+  color: #1a1a1a;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.nav {
+  background: #1a1a2e;
+  color: white;
+  padding: 0 1.5rem;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-brand {
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin-right: auto;
+}
+
+.nav a {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.nav a.active,
+.nav a:hover {
+  color: white;
+}
+
+.main {
+  flex: 1;
+  padding: 2rem 1.5rem;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,24 @@
+import { Routes, Route, NavLink } from 'react-router-dom';
+import Dashboard from './pages/Dashboard';
+import TradeDetail from './pages/TradeDetail';
+import CreateTrade from './pages/CreateTrade';
+import './App.css';
+
+export default function App() {
+  return (
+    <div className="app">
+      <nav className="nav">
+        <span className="nav-brand">StellarEscrow</span>
+        <NavLink to="/" end>Dashboard</NavLink>
+        <NavLink to="/trades/new">New Trade</NavLink>
+      </nav>
+      <main className="main">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/trades/new" element={<CreateTrade />} />
+          <Route path="/trades/:id" element={<TradeDetail />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+import { BrowserRouter } from 'react-router-dom';
+import { store, persistor } from '@stellar-escrow/state';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </PersistGate>
+    </Provider>
+  </React.StrictMode>
+);

--- a/app/src/pages/CreateTrade.tsx
+++ b/app/src/pages/CreateTrade.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { useCreateTradeMutation } from '@stellar-escrow/state';
+import { TradeForm, type TradeFormData } from '@stellar-escrow/components';
+
+export default function CreateTrade() {
+  const navigate = useNavigate();
+  const [createTrade, { isLoading, error }] = useCreateTradeMutation();
+
+  const handleSubmit = async (data: TradeFormData) => {
+    const result = await createTrade(data);
+    if ('data' in result) {
+      navigate(`/trades/${result.data.id}`);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <h1 style={{ fontSize: '1.5rem', marginBottom: '1.5rem' }}>Create Trade</h1>
+      {error && <p style={{ color: 'red', marginBottom: '1rem' }}>Failed to create trade.</p>}
+      <TradeForm onSubmit={handleSubmit} loading={isLoading} />
+    </div>
+  );
+}

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,0 +1,39 @@
+import { Link } from 'react-router-dom';
+import { useGetTradesQuery } from '@stellar-escrow/state';
+import { TradeCard } from '@stellar-escrow/components';
+
+export default function Dashboard() {
+  const { data: trades = [], isLoading, error } = useGetTradesQuery({});
+
+  if (isLoading) return <p>Loading trades…</p>;
+  if (error) return <p>Failed to load trades.</p>;
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem' }}>Trades</h1>
+        <Link to="/trades/new" style={{ padding: '0.5rem 1rem', background: '#1a1a2e', color: 'white', borderRadius: 6, textDecoration: 'none' }}>
+          + New Trade
+        </Link>
+      </div>
+      {trades.length === 0 ? (
+        <p style={{ color: '#666' }}>No trades yet.</p>
+      ) : (
+        <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}>
+          {trades.map((trade) => (
+            <Link key={trade.id} to={`/trades/${trade.id}`} style={{ textDecoration: 'none' }}>
+              <TradeCard
+                tradeId={trade.id}
+                seller={trade.seller}
+                buyer={trade.buyer}
+                amount={trade.amount}
+                status={trade.status}
+                timestamp={trade.timestamp}
+              />
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/pages/TradeDetail.tsx
+++ b/app/src/pages/TradeDetail.tsx
@@ -1,0 +1,32 @@
+import { useParams, Link } from 'react-router-dom';
+import { useGetTradeQuery, useGetEventsByTradeQuery } from '@stellar-escrow/state';
+import { TradeCard, EventFeed } from '@stellar-escrow/components';
+
+export default function TradeDetail() {
+  const { id } = useParams<{ id: string }>();
+  const { data: trade, isLoading, error } = useGetTradeQuery(id!);
+  const { data: events = [] } = useGetEventsByTradeQuery(id!);
+
+  if (isLoading) return <p>Loading…</p>;
+  if (error || !trade) return <p>Trade not found. <Link to="/">Back</Link></p>;
+
+  return (
+    <div style={{ display: 'grid', gap: '1.5rem', gridTemplateColumns: '1fr 1fr' }}>
+      <div>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '1rem' }}>Trade #{trade.id}</h1>
+        <TradeCard
+          tradeId={trade.id}
+          seller={trade.seller}
+          buyer={trade.buyer}
+          amount={trade.amount}
+          status={trade.status}
+          timestamp={trade.timestamp}
+        />
+      </div>
+      <div>
+        <h2 style={{ fontSize: '1.1rem', marginBottom: '1rem' }}>Events</h2>
+        <EventFeed events={events} />
+      </div>
+    </div>
+  );
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "paths": {
+      "@stellar-escrow/components": ["../components/src"],
+      "@stellar-escrow/state": ["../state/src"]
+    }
+  },
+  "include": ["src"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3001,
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+  resolve: {
+    alias: {
+      '@stellar-escrow/components': '../components/src',
+      '@stellar-escrow/state': '../state/src',
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "stellar-escrow",
   "private": true,
   "scripts": {
+    "dev": "npm run dev --workspace=app",
+    "build": "npm run build --workspace=app",
     "test": "npm run test --workspaces --if-present",
     "test:coverage": "npm run test:coverage --workspaces --if-present",
     "test:e2e": "npm run test:e2e --workspace=components"
   },
   "workspaces": [
+    "app",
     "components",
     "api",
     "state",


### PR DESCRIPTION
## Summary
Closes #27

Sets up the core React application with TypeScript, routing, and state management by wiring together the existing `state/` and `components/` packages into a new `app/` workspace.

## Changes
- **`app/`** — new Vite + React 18 + TypeScript workspace
- **Routing** — React Router v6 with three routes: `/` (Dashboard), `/trades/new` (CreateTrade), `/trades/:id` (TradeDetail)
- **State** — Redux `Provider` + `PersistGate` using the existing `stellar-escrow-state` package (RTK Query, slices, persistence already configured)
- **UI** — reuses existing `@stellar-escrow/components` (TradeCard, TradeForm, EventFeed) — no duplication
- **Build** — Vite with dev proxy `/api → :3000` (indexer), path aliases for local packages
- **Root `package.json`** — added `app` to workspaces, added `dev` and `build` scripts

## Acceptance Criteria
- [x] React app with TypeScript
- [x] React Router for navigation
- [x] Redux Toolkit for state management (via existing `state/` package)
- [x] Component library integrated (via existing `components/` package)
- [x] Dev environment and build tools (Vite)