### PR TITLE
feat: Kubernetes deployment manifests (#83)

### DIFF
--- a/k8s/api/api.yaml
+++ b/k8s/api/api.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: stellar-escrow
+  labels:
+    app: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: stellar-escrow/api:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4000
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: stellar-escrow-secrets
+                  key: DATABASE_URL
+            - name: INDEXER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: stellar-escrow-config
+                  key: INDEXER_URL
+            - name: NODE_ENV
+              value: production
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: stellar-escrow
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 4000
+      targetPort: 4000
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: stellar-escrow
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stellar-escrow-config
+  namespace: stellar-escrow
+data:
+  RUST_LOG: "info"
+  SERVER_PORT: "3000"
+  API_PORT: "4000"
+  CLIENT_PORT: "3001"
+  INDEXER_URL: "http://indexer:3000"
+  PUBLIC_API_URL: "http://api:4000"
+  PUBLIC_INDEXER_URL: "http://indexer:3000"

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stellar-escrow-ingress
+  namespace: stellar-escrow
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+spec:
+  tls:
+    - hosts:
+        - stellarescrow.app
+        - api.stellarescrow.app
+      secretName: stellar-escrow-tls
+  rules:
+    - host: stellarescrow.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: client
+                port:
+                  number: 3001
+    - host: api.stellarescrow.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 4000
+          - path: /indexer
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stellar-escrow

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -1,0 +1,13 @@
+# kubectl create secret generic stellar-escrow-secrets \
+#   --from-literal=DATABASE_URL="postgres://indexer:<password>@postgres:5432/stellar_escrow" \
+#   --from-literal=POSTGRES_PASSWORD="<password>" \
+#   -n stellar-escrow --dry-run=client -o yaml | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: stellar-escrow-secrets
+  namespace: stellar-escrow
+type: Opaque
+stringData:
+  DATABASE_URL: "postgres://indexer:password@postgres:5432/stellar_escrow"
+  POSTGRES_PASSWORD: "password"

--- a/k8s/client/client.yaml
+++ b/k8s/client/client.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+  namespace: stellar-escrow
+  labels:
+    app: client
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: client
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      containers:
+        - name: client
+          image: stellar-escrow/client:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3001
+          env:
+            - name: PUBLIC_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: stellar-escrow-config
+                  key: PUBLIC_API_URL
+            - name: PUBLIC_INDEXER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: stellar-escrow-config
+                  key: PUBLIC_INDEXER_URL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: client
+  namespace: stellar-escrow
+spec:
+  selector:
+    app: client
+  ports:
+    - port: 3001
+      targetPort: 3001
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: client-hpa
+  namespace: stellar-escrow
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: client
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/indexer/indexer.yaml
+++ b/k8s/indexer/indexer.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+  namespace: stellar-escrow
+  labels:
+    app: indexer
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: indexer
+  template:
+    metadata:
+      labels:
+        app: indexer
+    spec:
+      containers:
+        - name: indexer
+          image: stellar-escrow/indexer:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: stellar-escrow-secrets
+                  key: DATABASE_URL
+            - name: RUST_LOG
+              valueFrom:
+                configMapKeyRef:
+                  name: stellar-escrow-config
+                  key: RUST_LOG
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: indexer
+  namespace: stellar-escrow
+spec:
+  selector:
+    app: indexer
+  ports:
+    - port: 3000
+      targetPort: 3000
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: indexer-hpa
+  namespace: stellar-escrow
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: indexer
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: stellar-escrow
+
+resources:
+  - base/namespace.yaml
+  - base/secrets.yaml
+  - base/configmap.yaml
+  - base/ingress.yaml
+  - postgres/postgres.yaml
+  - indexer/indexer.yaml
+  - api/api.yaml
+  - client/client.yaml

--- a/k8s/postgres/postgres.yaml
+++ b/k8s/postgres/postgres.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: stellar-escrow
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: stellar-escrow
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: stellar_escrow
+            - name: POSTGRES_USER
+              value: indexer
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: stellar-escrow-secrets
+                  key: POSTGRES_PASSWORD
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "indexer", "-d", "stellar_escrow"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "indexer", "-d", "stellar_escrow"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: stellar-escrow
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  clusterIP: None  # headless for StatefulSet DNS


### PR DESCRIPTION
- Namespace, ConfigMap, Secrets (base/)
- PostgreSQL StatefulSet + headless Service + PVC (postgres/)
- Indexer Deployment + Service + HPA 2-8 replicas (indexer/)
- API Deployment + Service + HPA 2-6 replicas (api/)
- Client Deployment + Service + HPA 2-6 replicas (client/)
- NGINX Ingress with TLS + cert-manager annotations (base/ingress.yaml)
- Resource requests/limits on all containers
- Liveness + readiness probes on all services
- kustomization.yaml for single kubectl apply -k k8s/

Closes #83 