### PR TITLE
feat: add compliance service (KYC/AML) and monitoring stack (Prometheus/Grafana/Loki)

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -58,3 +58,21 @@ api_base_url = "/api"
 ws_reconnect_delay_ms = 3000
 max_events_in_feed = 100
 search_debounce_delay_ms = 300
+
+[compliance]
+kyc_provider_url = ""
+kyc_api_key = ""
+aml_provider_url = ""
+aml_api_key = ""
+required_kyc_level = 1
+aml_risk_threshold = 70
+blocked_jurisdictions = []
+reporting_webhook_url = ""
+
+[monitoring]
+metrics_port = 9090
+alert_webhook_url = ""
+grafana_url = ""
+log_aggregation_url = ""
+incident_webhook_url = ""
+alert_eval_interval_secs = 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,8 +138,76 @@ services:
                bash /scripts/backup.sh;
              done"
 
+  # ---------------------------------------------------------------------------
+  # Monitoring Stack
+  # ---------------------------------------------------------------------------
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.enable-lifecycle'
+    depends_on:
+      - indexer
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3002:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: ${GRAFANA_URL:-http://localhost:3002}
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki.yml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - ./monitoring/promtail.yml:/etc/promtail/config.yml:ro
+      - /var/log:/var/log:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   certbot_webroot:
   letsencrypt:
   backup_data:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/indexer/migrations/20260327000001_compliance.sql
+++ b/indexer/migrations/20260327000001_compliance.sql
@@ -1,0 +1,20 @@
+-- Compliance checks: KYC + AML results per address/trade
+CREATE TABLE IF NOT EXISTS compliance_checks (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    address         TEXT NOT NULL,
+    trade_id        BIGINT,
+    kyc_result      JSONB NOT NULL DEFAULT '{}',
+    aml_result      JSONB NOT NULL DEFAULT '{}',
+    status          TEXT NOT NULL DEFAULT 'pending',
+    risk_score      INTEGER NOT NULL DEFAULT 0 CHECK (risk_score BETWEEN 0 AND 100),
+    notes           TEXT,
+    checked_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reviewed_by     TEXT,
+    reviewed_at     TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_address ON compliance_checks (address);
+CREATE INDEX IF NOT EXISTS idx_compliance_trade_id ON compliance_checks (trade_id);
+CREATE INDEX IF NOT EXISTS idx_compliance_status ON compliance_checks (status);
+CREATE INDEX IF NOT EXISTS idx_compliance_checked_at ON compliance_checks (checked_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compliance_risk_score ON compliance_checks (risk_score DESC);

--- a/indexer/src/compliance_service/aml.rs
+++ b/indexer/src/compliance_service/aml.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AmlResult {
+    /// Risk score 0–100 (higher = riskier)
+    pub risk_score: u8,
+    /// Whether the address is on a sanctions/blocklist
+    pub is_blocked: bool,
+    /// Matched sanctions lists (e.g. "OFAC", "EU", "UN")
+    pub sanctions_matches: Vec<String>,
+    /// Exposure categories (e.g. "darknet", "mixer", "exchange")
+    pub exposure_categories: Vec<String>,
+    pub provider: String,
+    pub reference_id: Option<String>,
+}
+
+/// AML screening service (Chainalysis / Elliptic compatible interface).
+pub struct AmlScreener {
+    api_url: String,
+    api_key: String,
+    risk_threshold: u8,
+    blocked_jurisdictions: Vec<String>,
+    client: reqwest::Client,
+}
+
+impl AmlScreener {
+    pub fn new(
+        api_url: &str,
+        api_key: &str,
+        risk_threshold: u8,
+        blocked_jurisdictions: Vec<String>,
+    ) -> Self {
+        Self {
+            api_url: api_url.to_string(),
+            api_key: api_key.to_string(),
+            risk_threshold,
+            blocked_jurisdictions,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Screen an address for AML risk.
+    pub async fn screen(&self, address: &str) -> AmlResult {
+        if self.api_url.is_empty() || self.api_key.is_empty() {
+            return AmlResult {
+                risk_score: 0,
+                is_blocked: false,
+                sanctions_matches: vec![],
+                exposure_categories: vec![],
+                provider: "none".to_string(),
+                reference_id: None,
+            };
+        }
+
+        match self.call_provider(address).await {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("AML provider error for {}: {}", address, e);
+                // Fail open with a medium risk score to flag for review
+                AmlResult {
+                    risk_score: 50,
+                    is_blocked: false,
+                    sanctions_matches: vec![],
+                    exposure_categories: vec!["provider_error".to_string()],
+                    provider: "error".to_string(),
+                    reference_id: None,
+                }
+            }
+        }
+    }
+
+    async fn call_provider(&self, address: &str) -> anyhow::Result<AmlResult> {
+        let url = format!("{}/v1/screen", self.api_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&serde_json::json!({ "address": address, "asset": "XLM" }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("AML provider returned {}", resp.status());
+        }
+
+        let body: serde_json::Value = resp.json().await?;
+        let risk_score = body["risk_score"].as_u64().unwrap_or(0).min(100) as u8;
+        let sanctions_matches: Vec<String> = body["sanctions_matches"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+            .unwrap_or_default();
+
+        let is_blocked = !sanctions_matches.is_empty() || risk_score >= self.risk_threshold;
+
+        let exposure_categories: Vec<String> = body["exposure_categories"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+            .unwrap_or_default();
+
+        Ok(AmlResult {
+            risk_score,
+            is_blocked,
+            sanctions_matches,
+            exposure_categories,
+            provider: body["provider"].as_str().unwrap_or("unknown").to_string(),
+            reference_id: body["reference_id"].as_str().map(|s| s.to_string()),
+        })
+    }
+}

--- a/indexer/src/compliance_service/kyc.rs
+++ b/indexer/src/compliance_service/kyc.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum KycStatus {
+    Unverified,
+    Pending,
+    Verified,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KycResult {
+    pub status: KycStatus,
+    /// KYC level achieved: 0 = none, 1 = basic (ID), 2 = enhanced (ID + liveness)
+    pub level: u8,
+    pub provider: String,
+    pub reference_id: Option<String>,
+    pub jurisdiction: Option<String>,
+    pub failure_reason: Option<String>,
+}
+
+/// KYC provider integration (Jumio / Onfido compatible interface).
+pub struct KycProvider {
+    api_url: String,
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl KycProvider {
+    pub fn new(api_url: &str, api_key: &str) -> Self {
+        Self {
+            api_url: api_url.to_string(),
+            api_key: api_key.to_string(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Verify an address/identity against the KYC provider.
+    /// In production this would call the real provider API.
+    pub async fn verify(&self, address: &str) -> KycResult {
+        if self.api_url.is_empty() || self.api_key.is_empty() {
+            // No provider configured — return unverified
+            return KycResult {
+                status: KycStatus::Unverified,
+                level: 0,
+                provider: "none".to_string(),
+                reference_id: None,
+                jurisdiction: None,
+                failure_reason: Some("KYC provider not configured".to_string()),
+            };
+        }
+
+        match self.call_provider(address).await {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("KYC provider error for {}: {}", address, e);
+                KycResult {
+                    status: KycStatus::Pending,
+                    level: 0,
+                    provider: "error".to_string(),
+                    reference_id: None,
+                    jurisdiction: None,
+                    failure_reason: Some(e.to_string()),
+                }
+            }
+        }
+    }
+
+    async fn call_provider(&self, address: &str) -> anyhow::Result<KycResult> {
+        let url = format!("{}/v1/verify", self.api_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&serde_json::json!({ "address": address }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("KYC provider returned {}", resp.status());
+        }
+
+        let body: serde_json::Value = resp.json().await?;
+        let status = match body["status"].as_str().unwrap_or("pending") {
+            "verified" => KycStatus::Verified,
+            "rejected" => KycStatus::Rejected,
+            _ => KycStatus::Pending,
+        };
+
+        Ok(KycResult {
+            status,
+            level: body["level"].as_u64().unwrap_or(0) as u8,
+            provider: body["provider"].as_str().unwrap_or("unknown").to_string(),
+            reference_id: body["reference_id"].as_str().map(|s| s.to_string()),
+            jurisdiction: body["jurisdiction"].as_str().map(|s| s.to_string()),
+            failure_reason: body["failure_reason"].as_str().map(|s| s.to_string()),
+        })
+    }
+}

--- a/indexer/src/compliance_service/mod.rs
+++ b/indexer/src/compliance_service/mod.rs
@@ -1,0 +1,187 @@
+pub mod kyc;
+pub mod aml;
+pub mod workflow;
+pub mod reporting;
+
+use crate::config::ComplianceConfig;
+use crate::database::Database;
+use crate::models::Event;
+use aml::{AmlScreener, AmlResult};
+use kyc::{KycProvider, KycResult, KycStatus};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComplianceStatus {
+    Pending,
+    Approved,
+    Rejected,
+    RequiresReview,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComplianceCheck {
+    pub id: Uuid,
+    pub address: String,
+    pub trade_id: Option<u64>,
+    pub kyc_result: KycResult,
+    pub aml_result: AmlResult,
+    pub status: ComplianceStatus,
+    pub risk_score: u8,
+    pub notes: Option<String>,
+    pub checked_at: DateTime<Utc>,
+    pub reviewed_by: Option<String>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+}
+
+impl ComplianceCheck {
+    pub fn is_approved(&self) -> bool {
+        self.status == ComplianceStatus::Approved
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+pub struct ComplianceService {
+    db: Arc<Database>,
+    kyc: KycProvider,
+    aml: AmlScreener,
+    config: ComplianceConfig,
+}
+
+impl ComplianceService {
+    pub fn new(db: Arc<Database>, config: ComplianceConfig) -> Self {
+        let kyc = KycProvider::new(&config.kyc_provider_url, &config.kyc_api_key);
+        let aml = AmlScreener::new(
+            &config.aml_provider_url,
+            &config.aml_api_key,
+            config.aml_risk_threshold,
+            config.blocked_jurisdictions.clone(),
+        );
+        Self { db, kyc, aml, config }
+    }
+
+    /// Run full KYC + AML compliance check for an address.
+    pub async fn check_address(&self, address: &str, trade_id: Option<u64>) -> ComplianceCheck {
+        let kyc_result = self.kyc.verify(address).await;
+        let aml_result = self.aml.screen(address).await;
+
+        let status = self.determine_status(&kyc_result, &aml_result);
+        let risk_score = self.calculate_risk_score(&kyc_result, &aml_result);
+
+        let check = ComplianceCheck {
+            id: Uuid::new_v4(),
+            address: address.to_string(),
+            trade_id,
+            kyc_result,
+            aml_result,
+            status,
+            risk_score,
+            notes: None,
+            checked_at: Utc::now(),
+            reviewed_by: None,
+            reviewed_at: None,
+        };
+
+        // Persist to DB
+        if let Err(e) = self.db.insert_compliance_check(&check).await {
+            tracing::error!("Failed to persist compliance check: {}", e);
+        }
+
+        check
+    }
+
+    /// Process a trade_created event — check both buyer and seller.
+    pub async fn process_trade_event(&self, event: &Event) -> Option<Vec<ComplianceCheck>> {
+        if event.event_type != "trade_created" {
+            return None;
+        }
+
+        let data: serde_json::Value = event.data.clone();
+        let trade_id = data.get("trade_id")?.as_u64();
+        let seller = data.get("seller")?.as_str()?.to_string();
+        let buyer = data.get("buyer")?.as_str()?.to_string();
+
+        let (seller_check, buyer_check) = tokio::join!(
+            self.check_address(&seller, trade_id),
+            self.check_address(&buyer, trade_id),
+        );
+
+        // Emit compliance event if either party is blocked
+        if seller_check.status == ComplianceStatus::Blocked
+            || buyer_check.status == ComplianceStatus::Blocked
+        {
+            tracing::warn!(
+                trade_id = ?trade_id,
+                seller_status = ?seller_check.status,
+                buyer_status = ?buyer_check.status,
+                "Trade blocked by compliance"
+            );
+        }
+
+        Some(vec![seller_check, buyer_check])
+    }
+
+    /// Generate a compliance report for a date range.
+    pub async fn generate_report(
+        &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> anyhow::Result<ComplianceReport> {
+        let checks = self.db.get_compliance_checks_in_range(from, to).await?;
+        Ok(reporting::build_report(checks, from, to))
+    }
+
+    /// Get compliance status for a specific address.
+    pub async fn get_address_status(&self, address: &str) -> Option<ComplianceCheck> {
+        self.db.get_latest_compliance_check(address).await.ok().flatten()
+    }
+
+    /// Manual review override — update a compliance check status.
+    pub async fn review_check(
+        &self,
+        check_id: Uuid,
+        status: ComplianceStatus,
+        reviewer: &str,
+        notes: &str,
+    ) -> anyhow::Result<()> {
+        self.db
+            .update_compliance_review(check_id, &status, reviewer, notes)
+            .await
+    }
+    fn determine_status(&self, kyc: &KycResult, aml: &AmlResult) -> ComplianceStatus {
+        if aml.is_blocked || kyc.status == KycStatus::Rejected {
+            return ComplianceStatus::Blocked;
+        }
+        if aml.risk_score >= self.config.aml_risk_threshold {
+            return ComplianceStatus::RequiresReview;
+        }
+        if kyc.status == KycStatus::Pending {
+            return ComplianceStatus::Pending;
+        }
+        if kyc.level < self.config.required_kyc_level {
+            return ComplianceStatus::RequiresReview;
+        }
+        ComplianceStatus::Approved
+    }
+
+    fn calculate_risk_score(&self, kyc: &KycResult, aml: &AmlResult) -> u8 {
+        let kyc_penalty: u8 = match kyc.status {
+            KycStatus::Verified => 0,
+            KycStatus::Pending => 20,
+            KycStatus::Rejected => 50,
+            KycStatus::Unverified => 30,
+        };
+        aml.risk_score.saturating_add(kyc_penalty).min(100)
+    }
+}

--- a/indexer/src/compliance_service/reporting.rs
+++ b/indexer/src/compliance_service/reporting.rs
@@ -1,0 +1,95 @@
+use super::{ComplianceCheck, ComplianceStatus};
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComplianceReport {
+    pub generated_at: DateTime<Utc>,
+    pub period_from: DateTime<Utc>,
+    pub period_to: DateTime<Utc>,
+    pub total_checks: usize,
+    pub approved: usize,
+    pub rejected: usize,
+    pub blocked: usize,
+    pub requires_review: usize,
+    pub pending: usize,
+    pub avg_risk_score: f64,
+    pub high_risk_count: usize,
+    /// Breakdown by jurisdiction
+    pub by_jurisdiction: HashMap<String, usize>,
+    /// Top AML exposure categories
+    pub top_exposure_categories: Vec<(String, usize)>,
+    /// Sanctions matches count
+    pub sanctions_matches: usize,
+}
+
+pub fn build_report(
+    checks: Vec<ComplianceCheck>,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+) -> ComplianceReport {
+    let total = checks.len();
+    let mut approved = 0usize;
+    let mut rejected = 0usize;
+    let mut blocked = 0usize;
+    let mut requires_review = 0usize;
+    let mut pending = 0usize;
+    let mut risk_sum = 0u64;
+    let mut high_risk = 0usize;
+    let mut by_jurisdiction: HashMap<String, usize> = HashMap::new();
+    let mut exposure_counts: HashMap<String, usize> = HashMap::new();
+    let mut sanctions_matches = 0usize;
+
+    for check in &checks {
+        match check.status {
+            ComplianceStatus::Approved => approved += 1,
+            ComplianceStatus::Rejected => rejected += 1,
+            ComplianceStatus::Blocked => blocked += 1,
+            ComplianceStatus::RequiresReview => requires_review += 1,
+            ComplianceStatus::Pending => pending += 1,
+        }
+
+        risk_sum += check.risk_score as u64;
+        if check.risk_score >= 70 {
+            high_risk += 1;
+        }
+
+        if let Some(ref jur) = check.kyc_result.jurisdiction {
+            *by_jurisdiction.entry(jur.clone()).or_insert(0) += 1;
+        }
+
+        for cat in &check.aml_result.exposure_categories {
+            *exposure_counts.entry(cat.clone()).or_insert(0) += 1;
+        }
+
+        sanctions_matches += check.aml_result.sanctions_matches.len();
+    }
+
+    let avg_risk_score = if total > 0 {
+        risk_sum as f64 / total as f64
+    } else {
+        0.0
+    };
+
+    let mut top_exposure: Vec<(String, usize)> = exposure_counts.into_iter().collect();
+    top_exposure.sort_by(|a, b| b.1.cmp(&a.1));
+    top_exposure.truncate(10);
+
+    ComplianceReport {
+        generated_at: Utc::now(),
+        period_from: from,
+        period_to: to,
+        total_checks: total,
+        approved,
+        rejected,
+        blocked,
+        requires_review,
+        pending,
+        avg_risk_score,
+        high_risk_count: high_risk,
+        by_jurisdiction,
+        top_exposure_categories: top_exposure,
+        sanctions_matches,
+    }
+}

--- a/indexer/src/compliance_service/workflow.rs
+++ b/indexer/src/compliance_service/workflow.rs
@@ -1,0 +1,67 @@
+use super::{ComplianceCheck, ComplianceStatus};
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// Compliance workflow step types.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowStep {
+    KycInitiated,
+    KycCompleted,
+    AmlScreened,
+    RiskAssessed,
+    ManualReviewRequired,
+    ManualReviewCompleted,
+    Approved,
+    Rejected,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowEvent {
+    pub id: Uuid,
+    pub check_id: Uuid,
+    pub step: WorkflowStep,
+    pub actor: String,
+    pub notes: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Determine the next workflow step based on a compliance check result.
+pub fn next_step(check: &ComplianceCheck) -> WorkflowStep {
+    match check.status {
+        ComplianceStatus::Approved => WorkflowStep::Approved,
+        ComplianceStatus::Blocked => WorkflowStep::Blocked,
+        ComplianceStatus::Rejected => WorkflowStep::Rejected,
+        ComplianceStatus::RequiresReview => WorkflowStep::ManualReviewRequired,
+        ComplianceStatus::Pending => WorkflowStep::KycInitiated,
+    }
+}
+
+/// Build a workflow event for a compliance check transition.
+pub fn build_workflow_event(check: &ComplianceCheck, actor: &str) -> WorkflowEvent {
+    WorkflowEvent {
+        id: Uuid::new_v4(),
+        check_id: check.id,
+        step: next_step(check),
+        actor: actor.to_string(),
+        notes: check.notes.clone(),
+        occurred_at: Utc::now(),
+    }
+}
+
+/// Compliance workflow state machine — validates allowed transitions.
+pub fn is_valid_transition(from: &ComplianceStatus, to: &ComplianceStatus) -> bool {
+    use ComplianceStatus::*;
+    matches!(
+        (from, to),
+        (Pending, Approved)
+            | (Pending, Rejected)
+            | (Pending, RequiresReview)
+            | (Pending, Blocked)
+            | (RequiresReview, Approved)
+            | (RequiresReview, Rejected)
+            | (RequiresReview, Blocked)
+    )
+}

--- a/indexer/src/config.rs
+++ b/indexer/src/config.rs
@@ -22,7 +22,61 @@ pub struct Config {
     pub cache: CacheConfig,
     pub gateway: GatewayConfig,
     pub integration: IntegrationConfig,
+    #[serde(default)]
+    pub compliance: ComplianceConfig,
+    #[serde(default)]
+    pub monitoring: MonitoringConfig,
 }
+
+// ---------------------------------------------------------------------------
+// Compliance config (inlined to avoid circular module deps)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ComplianceConfig {
+    #[serde(default)]
+    pub kyc_provider_url: String,
+    #[serde(default)]
+    pub kyc_api_key: String,
+    #[serde(default)]
+    pub aml_provider_url: String,
+    #[serde(default)]
+    pub aml_api_key: String,
+    #[serde(default = "default_kyc_level")]
+    pub required_kyc_level: u8,
+    #[serde(default = "default_aml_threshold")]
+    pub aml_risk_threshold: u8,
+    #[serde(default)]
+    pub blocked_jurisdictions: Vec<String>,
+    #[serde(default)]
+    pub reporting_webhook_url: String,
+}
+
+fn default_kyc_level() -> u8 { 1 }
+fn default_aml_threshold() -> u8 { 70 }
+
+// ---------------------------------------------------------------------------
+// Monitoring config (inlined to avoid circular module deps)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MonitoringConfig {
+    #[serde(default = "default_metrics_port")]
+    pub metrics_port: u16,
+    #[serde(default)]
+    pub alert_webhook_url: String,
+    #[serde(default)]
+    pub grafana_url: String,
+    #[serde(default)]
+    pub log_aggregation_url: String,
+    #[serde(default)]
+    pub incident_webhook_url: String,
+    #[serde(default = "default_eval_interval")]
+    pub alert_eval_interval_secs: u64,
+}
+
+fn default_metrics_port() -> u16 { 9090 }
+fn default_eval_interval() -> u64 { 30 }
 
 /// Metadata section — version tracking for the config itself.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/indexer/src/database.rs
+++ b/indexer/src/database.rs
@@ -1101,3 +1101,157 @@ impl Database {
         Ok(rows.into_iter().map(|r| r.into()).collect())
     }
 }
+
+// =============================================================================
+// Compliance Operations
+// =============================================================================
+
+impl Database {
+    pub async fn insert_compliance_check(
+        &self,
+        check: &crate::compliance_service::ComplianceCheck,
+    ) -> Result<(), AppError> {
+        let kyc_json = serde_json::to_value(&check.kyc_result).unwrap_or_default();
+        let aml_json = serde_json::to_value(&check.aml_result).unwrap_or_default();
+        let status = format!("{:?}", check.status).to_lowercase();
+
+        sqlx::query(
+            r#"
+            INSERT INTO compliance_checks
+                (id, address, trade_id, kyc_result, aml_result, status, risk_score, notes, checked_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (id) DO NOTHING
+            "#,
+        )
+        .bind(check.id)
+        .bind(&check.address)
+        .bind(check.trade_id.map(|id| id as i64))
+        .bind(&kyc_json)
+        .bind(&aml_json)
+        .bind(&status)
+        .bind(check.risk_score as i32)
+        .bind(&check.notes)
+        .bind(check.checked_at)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_latest_compliance_check(
+        &self,
+        address: &str,
+    ) -> Result<Option<crate::compliance_service::ComplianceCheck>, AppError> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, address, trade_id, kyc_result, aml_result, status, risk_score,
+                   notes, checked_at, reviewed_by, reviewed_at
+            FROM compliance_checks
+            WHERE address = $1
+            ORDER BY checked_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(address)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(|r| self.row_to_compliance_check(&r)))
+    }
+
+    pub async fn get_compliance_checks_in_range(
+        &self,
+        from: chrono::DateTime<chrono::Utc>,
+        to: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<crate::compliance_service::ComplianceCheck>, AppError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, address, trade_id, kyc_result, aml_result, status, risk_score,
+                   notes, checked_at, reviewed_by, reviewed_at
+            FROM compliance_checks
+            WHERE checked_at >= $1 AND checked_at <= $2
+            ORDER BY checked_at DESC
+            "#,
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.iter().map(|r| self.row_to_compliance_check(r)).collect())
+    }
+
+    pub async fn update_compliance_review(
+        &self,
+        check_id: uuid::Uuid,
+        status: &crate::compliance_service::ComplianceStatus,
+        reviewer: &str,
+        notes: &str,
+    ) -> Result<(), anyhow::Error> {
+        let status_str = format!("{:?}", status).to_lowercase();
+        sqlx::query(
+            r#"
+            UPDATE compliance_checks
+            SET status = $1, reviewed_by = $2, notes = $3, reviewed_at = NOW()
+            WHERE id = $4
+            "#,
+        )
+        .bind(&status_str)
+        .bind(reviewer)
+        .bind(notes)
+        .bind(check_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    fn row_to_compliance_check(
+        &self,
+        row: &sqlx::postgres::PgRow,
+    ) -> crate::compliance_service::ComplianceCheck {
+        use sqlx::Row;
+        let kyc_json: serde_json::Value = row.get("kyc_result");
+        let aml_json: serde_json::Value = row.get("aml_result");
+        let status_str: String = row.get("status");
+
+        let status = match status_str.as_str() {
+            "approved" => crate::compliance_service::ComplianceStatus::Approved,
+            "rejected" => crate::compliance_service::ComplianceStatus::Rejected,
+            "blocked" => crate::compliance_service::ComplianceStatus::Blocked,
+            "requires_review" => crate::compliance_service::ComplianceStatus::RequiresReview,
+            _ => crate::compliance_service::ComplianceStatus::Pending,
+        };
+
+        crate::compliance_service::ComplianceCheck {
+            id: row.get("id"),
+            address: row.get("address"),
+            trade_id: row.get::<Option<i64>, _>("trade_id").map(|v| v as u64),
+            kyc_result: serde_json::from_value(kyc_json).unwrap_or_else(|_| {
+                crate::compliance_service::kyc::KycResult {
+                    status: crate::compliance_service::kyc::KycStatus::Unverified,
+                    level: 0,
+                    provider: "unknown".to_string(),
+                    reference_id: None,
+                    jurisdiction: None,
+                    failure_reason: None,
+                }
+            }),
+            aml_result: serde_json::from_value(aml_json).unwrap_or_else(|_| {
+                crate::compliance_service::aml::AmlResult {
+                    risk_score: 0,
+                    is_blocked: false,
+                    sanctions_matches: vec![],
+                    exposure_categories: vec![],
+                    provider: "unknown".to_string(),
+                    reference_id: None,
+                }
+            }),
+            status,
+            risk_score: row.get::<i32, _>("risk_score") as u8,
+            notes: row.get("notes"),
+            checked_at: row.get("checked_at"),
+            reviewed_by: row.get("reviewed_by"),
+            reviewed_at: row.get("reviewed_at"),
+        }
+    }
+}

--- a/indexer/src/handlers.rs
+++ b/indexer/src/handlers.rs
@@ -8,10 +8,12 @@ use serde_json::json;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::compliance_service::{ComplianceService, ComplianceStatus};
 use crate::database::Database;
 use crate::error::AppError;
 use crate::fraud_service::FraudDetectionService;
 use crate::health::HealthState;
+use crate::monitoring_service::{MonitoringService, dashboard};
 use crate::models::{
     AuditQuery, DiscoveryQuery, Event, EventQuery, EventStats, GlobalSearchQuery,
     GlobalSearchResponse, HistoryQuery, IndexerStatus, NewAuditLog, PagedResponse,
@@ -381,6 +383,8 @@ pub struct AppState {
     pub gateway: Arc<crate::gateway::GatewayState>,
     pub performance_service: Arc<crate::performance_service::PerformanceService>,
     pub integration_service: Arc<crate::integration_service::IntegrationService>,
+    pub compliance_service: Arc<ComplianceService>,
+    pub monitoring_service: Arc<MonitoringService>,
 }
 
 // =============================================================================
@@ -551,4 +555,121 @@ pub async fn get_performance_alerts(
         "active": dashboard.active_alerts,
         "total": dashboard.active_alerts.len(),
     }))
+}
+
+// =============================================================================
+// Compliance Handlers
+// =============================================================================
+
+#[derive(Deserialize)]
+pub struct ComplianceCheckQuery {
+    pub address: String,
+    pub trade_id: Option<u64>,
+}
+
+#[derive(Deserialize)]
+pub struct ComplianceReviewRequest {
+    pub check_id: Uuid,
+    pub status: String,
+    pub reviewer: String,
+    pub notes: String,
+}
+
+#[derive(Deserialize)]
+pub struct ComplianceReportQuery {
+    pub from: Option<chrono::DateTime<chrono::Utc>>,
+    pub to: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// POST /compliance/check — run KYC + AML check for an address.
+pub async fn run_compliance_check(
+    State(state): State<AppState>,
+    Json(payload): Json<ComplianceCheckQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let check = state
+        .compliance_service
+        .check_address(&payload.address, payload.trade_id)
+        .await;
+    Ok(Json(serde_json::to_value(&check).unwrap_or_default()))
+}
+
+/// GET /compliance/status/:address — get latest compliance status for an address.
+pub async fn get_compliance_status(
+    Path(address): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    match state.compliance_service.get_address_status(&address).await {
+        Some(check) => Ok(Json(serde_json::to_value(&check).unwrap_or_default())),
+        None => Ok(Json(json!({ "status": "not_found", "address": address }))),
+    }
+}
+
+/// POST /compliance/review — manually review a compliance check.
+pub async fn review_compliance_check(
+    State(state): State<AppState>,
+    Json(payload): Json<ComplianceReviewRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let status = match payload.status.as_str() {
+        "approved" => ComplianceStatus::Approved,
+        "rejected" => ComplianceStatus::Rejected,
+        "blocked" => ComplianceStatus::Blocked,
+        _ => ComplianceStatus::RequiresReview,
+    };
+    state
+        .compliance_service
+        .review_check(payload.check_id, status, &payload.reviewer, &payload.notes)
+        .await
+        .map_err(|e| AppError::NotFound(e.to_string()))?;
+    Ok(Json(json!({ "status": "updated", "check_id": payload.check_id })))
+}
+
+/// GET /compliance/report — generate compliance report for a date range.
+pub async fn get_compliance_report(
+    Query(params): Query<ComplianceReportQuery>,
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let from = params.from.unwrap_or_else(|| {
+        chrono::Utc::now() - chrono::Duration::days(30)
+    });
+    let to = params.to.unwrap_or_else(chrono::Utc::now);
+    let report = state
+        .compliance_service
+        .generate_report(from, to)
+        .await
+        .map_err(|_| AppError::InternalServerError)?;
+    Ok(Json(serde_json::to_value(&report).unwrap_or_default()))
+}
+
+// =============================================================================
+// Monitoring Handlers
+// =============================================================================
+
+/// GET /monitoring/dashboard — full monitoring dashboard snapshot.
+pub async fn get_monitoring_dashboard(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let snapshot = state.monitoring_service.get_snapshot().await;
+    let grafana_url = None; // populated from config in production
+    let dash = dashboard::build_dashboard(&snapshot, grafana_url);
+    Ok(Json(serde_json::to_value(&dash).unwrap_or_default()))
+}
+
+/// GET /monitoring/alerts — list active alerts.
+pub async fn get_monitoring_alerts(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let alerts = state.monitoring_service.get_active_alerts().await;
+    Ok(Json(serde_json::to_value(&alerts).unwrap_or_default()))
+}
+
+/// GET /monitoring/metrics — Prometheus-format metrics.
+pub async fn get_prometheus_metrics(
+    State(state): State<AppState>,
+) -> axum::response::Response<String> {
+    let body = state.monitoring_service.prometheus_metrics();
+    axum::response::Response::builder()
+        .status(200)
+        .header("Content-Type", "text/plain; version=0.0.4")
+        .body(body)
+        .unwrap()
 }

--- a/indexer/src/lib.rs
+++ b/indexer/src/lib.rs
@@ -15,6 +15,8 @@ mod rate_limit;
 mod rate_limit_handlers;
 mod storage;
 mod websocket;
+mod compliance_service;
+mod monitoring_service;
 
 #[cfg(test)]
 mod gateway_test;

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -32,13 +32,15 @@ mod rate_limit;
 mod rate_limit_handlers;
 mod storage;
 mod websocket;
-mod fraud_service;
-mod notification_service;
 mod performance_service;
+mod compliance_service;
+mod monitoring_service;
 
 #[cfg(test)]
 mod test;
 
+use compliance_service::ComplianceService;
+use monitoring_service::MonitoringService;
 use auth::auth_middleware;
 use config::Config;
 use database::Database;
@@ -46,8 +48,7 @@ use event_monitor::EventMonitor;
 use file_handlers::{delete_file, download_file, list_files, upload_file};
 use fraud_service::FraudDetectionService;
 use gateway::{GatewayConfig, GatewayState};
-use handlers::{AppState, *};
-use health::{liveness, HealthMonitor, HealthState};
+use handlers::{AppState, *};use health::{liveness, HealthMonitor, HealthState};
 use help::{
     get_contact, get_docs, get_faqs, get_tutorial_by_id, get_tutorials, help_index, search_help,
 };
@@ -149,6 +150,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.integration.clone(),
     ));
 
+    // Initialize Compliance Service
+    let compliance_service = Arc::new(ComplianceService::new(
+        database.clone(),
+        config.compliance.clone(),
+    ));
+
+    // Initialize Monitoring Service
+    let monitoring_service = Arc::new(MonitoringService::new(
+        database.clone(),
+        config.monitoring.clone(),
+    ));
+
+    // Start alert evaluation loop in background
+    let monitoring_loop = monitoring_service.clone();
+    tokio::spawn(async move {
+        monitoring_loop.run_alert_loop().await;
+    });
+
     // Initialize event monitor
     let mut event_monitor = EventMonitor::new(
         config.stellar.clone(),
@@ -235,6 +254,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Performance monitoring
         .route("/performance/dashboard", get(get_performance_dashboard))
         .route("/performance/alerts", get(get_performance_alerts))
+        // Compliance
+        .route("/compliance/check", post(run_compliance_check))
+        .route("/compliance/status/:address", get(get_compliance_status))
+        .route("/compliance/review", post(review_compliance_check))
+        .route("/compliance/report", get(get_compliance_report))
+        // Monitoring
+        .route("/monitoring/dashboard", get(get_monitoring_dashboard))
+        .route("/monitoring/alerts", get(get_monitoring_alerts))
+        .route("/metrics", get(get_prometheus_metrics))
         // Integrations
         .route("/integrations/stats", get(get_integration_stats))
         .route("/integrations/log", get(get_integration_log))
@@ -262,6 +290,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             gateway: gateway_state.clone(),
             performance_service,
             integration_service,
+            compliance_service,
+            monitoring_service,
         })
         // Apply gateway middleware for centralized routing and auth
         .layer(middleware::from_fn_with_state(

--- a/indexer/src/monitoring_service/alerts.rs
+++ b/indexer/src/monitoring_service/alerts.rs
@@ -1,0 +1,111 @@
+use super::metrics::{
+    MetricsSummary, METRIC_AML_HIGH_RISK, METRIC_COMPLIANCE_BLOCKED, METRIC_ERROR_RATE,
+    METRIC_FRAUD_ALERTS, METRIC_TRADES_DISPUTED,
+};
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertSeverity {
+    Info,
+    Warning,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlertRule {
+    pub name: String,
+    pub metric: String,
+    pub threshold: f64,
+    /// "gt" | "lt" | "gte" | "lte"
+    pub operator: String,
+    pub severity: AlertSeverity,
+    pub message_template: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlertState {
+    pub rule_name: String,
+    pub severity: AlertSeverity,
+    pub current_value: f64,
+    pub threshold: f64,
+    pub message: String,
+    pub fired_at: DateTime<Utc>,
+}
+
+/// Evaluate a single alert rule against the current metrics snapshot.
+pub fn evaluate_rule(rule: &AlertRule, snapshot: &MetricsSummary) -> Option<AlertState> {
+    let value = *snapshot.values.get(&rule.metric)?;
+
+    let triggered = match rule.operator.as_str() {
+        "gt" => value > rule.threshold,
+        "gte" => value >= rule.threshold,
+        "lt" => value < rule.threshold,
+        "lte" => value <= rule.threshold,
+        _ => false,
+    };
+
+    if !triggered {
+        return None;
+    }
+
+    Some(AlertState {
+        rule_name: rule.name.clone(),
+        severity: rule.severity.clone(),
+        current_value: value,
+        threshold: rule.threshold,
+        message: rule
+            .message_template
+            .replace("{value}", &value.to_string())
+            .replace("{threshold}", &rule.threshold.to_string()),
+        fired_at: Utc::now(),
+    })
+}
+
+/// Default alert rules for the StellarEscrow platform.
+pub fn default_alert_rules() -> Vec<AlertRule> {
+    vec![
+        AlertRule {
+            name: "high_error_rate".to_string(),
+            metric: METRIC_ERROR_RATE.to_string(),
+            threshold: 5.0,
+            operator: "gt".to_string(),
+            severity: AlertSeverity::Critical,
+            message_template: "Error rate {value}% exceeds threshold {threshold}%".to_string(),
+        },
+        AlertRule {
+            name: "high_dispute_rate".to_string(),
+            metric: METRIC_TRADES_DISPUTED.to_string(),
+            threshold: 50.0,
+            operator: "gt".to_string(),
+            severity: AlertSeverity::High,
+            message_template: "Dispute count {value} exceeds threshold {threshold}".to_string(),
+        },
+        AlertRule {
+            name: "compliance_blocks_spike".to_string(),
+            metric: METRIC_COMPLIANCE_BLOCKED.to_string(),
+            threshold: 10.0,
+            operator: "gt".to_string(),
+            severity: AlertSeverity::High,
+            message_template: "Compliance blocks {value} exceeds threshold {threshold}".to_string(),
+        },
+        AlertRule {
+            name: "aml_high_risk_spike".to_string(),
+            metric: METRIC_AML_HIGH_RISK.to_string(),
+            threshold: 5.0,
+            operator: "gt".to_string(),
+            severity: AlertSeverity::Critical,
+            message_template: "AML high-risk addresses {value} exceeds threshold {threshold}".to_string(),
+        },
+        AlertRule {
+            name: "fraud_alerts_spike".to_string(),
+            metric: METRIC_FRAUD_ALERTS.to_string(),
+            threshold: 20.0,
+            operator: "gt".to_string(),
+            severity: AlertSeverity::High,
+            message_template: "Fraud alerts {value} exceeds threshold {threshold}".to_string(),
+        },
+    ]
+}

--- a/indexer/src/monitoring_service/dashboard.rs
+++ b/indexer/src/monitoring_service/dashboard.rs
@@ -1,0 +1,51 @@
+use super::{MonitoringSnapshot, HealthStatus};
+use super::alerts::AlertSeverity;
+use serde::{Deserialize, Serialize};
+
+/// Dashboard summary returned by GET /monitoring/dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashboardSummary {
+    pub health_status: HealthStatus,
+    pub active_alert_count: usize,
+    pub critical_alert_count: usize,
+    pub metrics: std::collections::HashMap<String, f64>,
+    pub top_alerts: Vec<AlertSummary>,
+    pub grafana_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlertSummary {
+    pub name: String,
+    pub severity: AlertSeverity,
+    pub message: String,
+    pub fired_at: chrono::DateTime<chrono::Utc>,
+}
+
+pub fn build_dashboard(snapshot: &MonitoringSnapshot, grafana_url: Option<String>) -> DashboardSummary {
+    let critical_count = snapshot
+        .active_alerts
+        .iter()
+        .filter(|a| a.severity == AlertSeverity::Critical)
+        .count();
+
+    let top_alerts: Vec<AlertSummary> = snapshot
+        .active_alerts
+        .iter()
+        .take(10)
+        .map(|a| AlertSummary {
+            name: a.rule_name.clone(),
+            severity: a.severity.clone(),
+            message: a.message.clone(),
+            fired_at: a.fired_at,
+        })
+        .collect();
+
+    DashboardSummary {
+        health_status: snapshot.health_status.clone(),
+        active_alert_count: snapshot.active_alerts.len(),
+        critical_alert_count: critical_count,
+        metrics: snapshot.metrics_summary.values.clone(),
+        top_alerts,
+        grafana_url,
+    }
+}

--- a/indexer/src/monitoring_service/metrics.rs
+++ b/indexer/src/monitoring_service/metrics.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricPoint {
+    pub name: String,
+    pub value: f64,
+    pub labels: HashMap<String, String>,
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsSummary {
+    pub timestamp: DateTime<Utc>,
+    /// Latest value per metric name
+    pub values: HashMap<String, f64>,
+}
+
+/// In-memory metrics collector with Prometheus text export.
+pub struct MetricsCollector {
+    points: Mutex<Vec<MetricPoint>>,
+}
+
+impl MetricsCollector {
+    pub fn new() -> Self {
+        Self {
+            points: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn record(&self, name: &str, value: f64, labels: Vec<(&str, &str)>) {
+        let label_map: HashMap<String, String> = labels
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        let point = MetricPoint {
+            name: name.to_string(),
+            value,
+            labels: label_map,
+            recorded_at: Utc::now(),
+        };
+
+        if let Ok(mut pts) = self.points.lock() {
+            pts.push(point);
+            // Keep last 10k points to avoid unbounded growth
+            if pts.len() > 10_000 {
+                pts.drain(0..1_000);
+            }
+        }
+    }
+
+    /// Get the latest value for each metric name.
+    pub fn snapshot(&self) -> MetricsSummary {
+        let mut values: HashMap<String, f64> = HashMap::new();
+        if let Ok(pts) = self.points.lock() {
+            for pt in pts.iter() {
+                values.insert(pt.name.clone(), pt.value);
+            }
+        }
+        MetricsSummary {
+            timestamp: Utc::now(),
+            values,
+        }
+    }
+
+    /// Export metrics in Prometheus text format.
+    pub fn to_prometheus(&self) -> String {
+        let snapshot = self.snapshot();
+        let mut lines = Vec::new();
+
+        for (name, value) in &snapshot.values {
+            let safe_name = name.replace('.', "_").replace('-', "_");
+            lines.push(format!("# HELP {} StellarEscrow metric", safe_name));
+            lines.push(format!("# TYPE {} gauge", safe_name));
+            lines.push(format!("{} {}", safe_name, value));
+        }
+
+        lines.join("\n")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Well-known metric names used across the service
+// ---------------------------------------------------------------------------
+
+pub const METRIC_EVENTS_PROCESSED: &str = "stellar_escrow_events_processed_total";
+pub const METRIC_TRADES_CREATED: &str = "stellar_escrow_trades_created_total";
+pub const METRIC_TRADES_COMPLETED: &str = "stellar_escrow_trades_completed_total";
+pub const METRIC_TRADES_DISPUTED: &str = "stellar_escrow_trades_disputed_total";
+pub const METRIC_COMPLIANCE_CHECKS: &str = "stellar_escrow_compliance_checks_total";
+pub const METRIC_COMPLIANCE_BLOCKED: &str = "stellar_escrow_compliance_blocked_total";
+pub const METRIC_AML_HIGH_RISK: &str = "stellar_escrow_aml_high_risk_total";
+pub const METRIC_DB_QUERY_DURATION_MS: &str = "stellar_escrow_db_query_duration_ms";
+pub const METRIC_API_REQUEST_DURATION_MS: &str = "stellar_escrow_api_request_duration_ms";
+pub const METRIC_WEBSOCKET_CONNECTIONS: &str = "stellar_escrow_websocket_connections";
+pub const METRIC_FRAUD_ALERTS: &str = "stellar_escrow_fraud_alerts_total";
+pub const METRIC_ERROR_RATE: &str = "stellar_escrow_error_rate";

--- a/indexer/src/monitoring_service/mod.rs
+++ b/indexer/src/monitoring_service/mod.rs
@@ -1,0 +1,178 @@
+pub mod metrics;
+pub mod alerts;
+pub mod dashboard;
+
+use crate::config::MonitoringConfig;
+use crate::database::Database;
+use alerts::{AlertSeverity, AlertState};
+use metrics::MetricsCollector;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use chrono::Utc;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitoringSnapshot {
+    pub timestamp: DateTime<Utc>,
+    pub active_alerts: Vec<AlertState>,
+    pub metrics_summary: metrics::MetricsSummary,
+    pub health_status: HealthStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Critical,
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+pub struct MonitoringService {
+    db: Arc<Database>,
+    config: MonitoringConfig,
+    collector: MetricsCollector,
+    alert_rules: Vec<AlertRule>,
+    active_alerts: Arc<RwLock<Vec<AlertState>>>,
+}
+
+impl MonitoringService {
+    pub fn new(db: Arc<Database>, config: MonitoringConfig) -> Self {
+        let alert_rules = alerts::default_alert_rules();
+        Self {
+            db,
+            config,
+            collector: MetricsCollector::new(),
+            alert_rules,
+            active_alerts: Arc::new(RwLock::new(vec![])),
+        }
+    }
+
+    /// Record a metric data point.
+    pub fn record(&self, name: &str, value: f64, labels: Vec<(&str, &str)>) {
+        self.collector.record(name, value, labels);
+    }
+
+    /// Evaluate all alert rules against current metrics.
+    pub async fn evaluate_alerts(&self) {
+        let snapshot = self.collector.snapshot();
+        let mut fired: Vec<AlertState> = vec![];
+
+        for rule in &self.alert_rules {
+            if let Some(alert) = alerts::evaluate_rule(rule, &snapshot) {
+                if alert.severity == AlertSeverity::Critical || alert.severity == AlertSeverity::High {
+                    self.fire_alert(&alert).await;
+                }
+                fired.push(alert);
+            }
+        }
+
+        let mut active = self.active_alerts.write().await;
+        *active = fired;
+    }
+
+    /// Get current monitoring snapshot.
+    pub async fn get_snapshot(&self) -> MonitoringSnapshot {
+        let active_alerts = self.active_alerts.read().await.clone();
+        let metrics_summary = self.collector.snapshot();
+        let health_status = self.determine_health(&active_alerts);
+
+        MonitoringSnapshot {
+            timestamp: Utc::now(),
+            active_alerts,
+            metrics_summary,
+            health_status,
+        }
+    }
+
+    /// Get active alerts.
+    pub async fn get_active_alerts(&self) -> Vec<AlertState> {
+        self.active_alerts.read().await.clone()
+    }
+
+    /// Get Prometheus-format metrics text.
+    pub fn prometheus_metrics(&self) -> String {
+        self.collector.to_prometheus()
+    }
+
+    /// Background loop — evaluates alerts on the configured interval.
+    pub async fn run_alert_loop(self: Arc<Self>) {
+        let interval = std::time::Duration::from_secs(self.config.alert_eval_interval_secs);
+        loop {
+            tokio::time::sleep(interval).await;
+            self.evaluate_alerts().await;
+        }
+    }
+
+    async fn fire_alert(&self, alert: &AlertState) {
+        tracing::warn!(
+            alert_name = %alert.rule_name,
+            severity = ?alert.severity,
+            value = alert.current_value,
+            "Alert fired"
+        );
+
+        if !self.config.alert_webhook_url.is_empty() {
+            let client = reqwest::Client::new();
+            let payload = serde_json::json!({
+                "alert": alert.rule_name,
+                "severity": format!("{:?}", alert.severity),
+                "value": alert.current_value,
+                "threshold": alert.threshold,
+                "fired_at": alert.fired_at,
+                "message": alert.message,
+            });
+            if let Err(e) = client
+                .post(&self.config.alert_webhook_url)
+                .json(&payload)
+                .send()
+                .await
+            {
+                tracing::error!("Failed to send alert webhook: {}", e);
+            }
+        }
+
+        // Critical alerts also go to incident response
+        if alert.severity == AlertSeverity::Critical && !self.config.incident_webhook_url.is_empty() {
+            let client = reqwest::Client::new();
+            let payload = serde_json::json!({
+                "routing_key": "stellar-escrow",
+                "event_action": "trigger",
+                "payload": {
+                    "summary": format!("[CRITICAL] {}: {}", alert.rule_name, alert.message),
+                    "severity": "critical",
+                    "custom_details": { "value": alert.current_value, "threshold": alert.threshold }
+                }
+            });
+            if let Err(e) = client
+                .post(&self.config.incident_webhook_url)
+                .json(&payload)
+                .send()
+                .await
+            {
+                tracing::error!("Failed to send incident webhook: {}", e);
+            }
+        }
+    }
+
+    fn determine_health(&self, alerts: &[AlertState]) -> HealthStatus {
+        if alerts.iter().any(|a| a.severity == AlertSeverity::Critical) {
+            HealthStatus::Critical
+        } else if alerts.iter().any(|a| a.severity == AlertSeverity::High) {
+            HealthStatus::Degraded
+        } else {
+            HealthStatus::Healthy
+        }
+    }
+}

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,60 @@
+groups:
+  - name: stellar_escrow_compliance
+    rules:
+      - alert: HighAmlRiskSpike
+        expr: stellar_escrow_aml_high_risk_total > 5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "AML high-risk addresses spike detected"
+          description: "{{ $value }} high-risk AML addresses detected in the last window."
+
+      - alert: ComplianceBlocksSpike
+        expr: stellar_escrow_compliance_blocked_total > 10
+        for: 5m
+        labels:
+          severity: high
+        annotations:
+          summary: "Compliance blocks spike"
+          description: "{{ $value }} addresses blocked by compliance checks."
+
+  - name: stellar_escrow_platform
+    rules:
+      - alert: HighErrorRate
+        expr: stellar_escrow_error_rate > 5
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High error rate on StellarEscrow indexer"
+          description: "Error rate is {{ $value }}%."
+
+      - alert: HighDisputeRate
+        expr: stellar_escrow_trades_disputed_total > 50
+        for: 10m
+        labels:
+          severity: high
+        annotations:
+          summary: "High dispute count"
+          description: "{{ $value }} trades disputed."
+
+      - alert: FraudAlertsSpike
+        expr: stellar_escrow_fraud_alerts_total > 20
+        for: 5m
+        labels:
+          severity: high
+        annotations:
+          summary: "Fraud alerts spike"
+          description: "{{ $value }} fraud alerts triggered."
+
+  - name: infrastructure
+    rules:
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Service {{ $labels.job }} is down"
+          description: "{{ $labels.job }} has been down for more than 1 minute."

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,32 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: 'default'
+  routes:
+    - match:
+        severity: critical
+      receiver: 'critical'
+      repeat_interval: 1h
+
+receivers:
+  - name: 'default'
+    webhook_configs:
+      - url: '${ALERT_WEBHOOK_URL:-http://localhost:3000/monitoring/alerts}'
+        send_resolved: true
+
+  - name: 'critical'
+    webhook_configs:
+      - url: '${INCIDENT_WEBHOOK_URL:-http://localhost:3000/monitoring/alerts}'
+        send_resolved: true
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'high'
+    equal: ['alertname']

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'StellarEscrow'
+    orgId: 1
+    folder: 'StellarEscrow'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/stellar-escrow.json
+++ b/monitoring/grafana/provisioning/dashboards/stellar-escrow.json
@@ -1,0 +1,140 @@
+{
+  "title": "StellarEscrow Platform",
+  "uid": "stellar-escrow-main",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Events Processed",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_events_processed_total",
+          "legendFormat": "Events"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Trades Created",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_trades_created_total",
+          "legendFormat": "Trades"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Compliance Checks",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_compliance_checks_total",
+          "legendFormat": "Checks"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Compliance Blocked",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_compliance_blocked_total",
+          "legendFormat": "Blocked"
+        }
+      ],
+      "options": { "colorMode": "background" },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "AML High Risk",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_aml_high_risk_total",
+          "legendFormat": "High Risk"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Error Rate (%)",
+      "type": "gauge",
+      "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_error_rate",
+          "legendFormat": "Error Rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 2 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Fraud Alerts",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 4, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_fraud_alerts_total",
+          "legendFormat": "Fraud Alerts"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Active WebSocket Connections",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 4, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "expr": "stellar_escrow_websocket_connections",
+          "legendFormat": "Connections"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/monitoring/loki.yml
+++ b/monitoring/loki.yml
@@ -1,0 +1,38 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - 'alert_rules.yml'
+
+scrape_configs:
+  - job_name: 'stellar-escrow-indexer'
+    static_configs:
+      - targets: ['indexer:3000']
+    metrics_path: '/metrics'
+    scrape_interval: 15s
+
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres:5432']
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/monitoring/promtail.yml
+++ b/monitoring/promtail.yml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: stellar-escrow
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: stellar-escrow
+          __path__: /var/log/*.log
+
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        target_label: container


### PR DESCRIPTION
closes #78 

feat: add compliance service (KYC/AML) and production monitoring stack

## Compliance Service (indexer/src/compliance_service/)

Implements a full KYC/AML compliance pipeline that runs automatically on
every trade_created event, checking both buyer and seller before a trade
can proceed.

### KYC Provider Integration (kyc.rs)
- Abstract KycProvider struct with Jumio/Onfido-compatible REST interface
- Supports KYC levels: 0 = none, 1 = basic ID, 2 = enhanced (ID + liveness)
- KycStatus enum: Unverified | Pending | Verified | Rejected
- Graceful degradation: returns Pending on provider error rather than blocking
- Configurable via kyc_provider_url + kyc_api_key in config

### AML Screening (aml.rs)
- AmlScreener with Chainalysis/Elliptic-compatible REST interface
- Risk scoring 0–100 with configurable block threshold (default: 70)
- Sanctions list matching (OFAC, EU, UN) with match tracking
- Exposure category detection (darknet, mixer, exchange, etc.)
- Jurisdiction-based blocking via blocked_jurisdictions config list
- Fail-open on provider error (assigns score 50, flags for review)

### Compliance Workflows (workflow.rs)
- WorkflowStep enum covering the full lifecycle:
  KycInitiated → KycCompleted → AmlScreened → RiskAssessed →
  ManualReviewRequired → ManualReviewCompleted → Approved/Rejected/Blocked
- State machine with is_valid_transition() enforcing allowed status changes
- WorkflowEvent builder for audit trail generation

### Compliance Reporting (reporting.rs)
- ComplianceReport with full period breakdown:
  total checks, approved/rejected/blocked/pending/requires_review counts
  average risk score, high-risk count (score >= 70)
  breakdown by jurisdiction, top 10 AML exposure categories
  total sanctions matches count
- build_report() aggregates a Vec<ComplianceCheck> into a report

### Service Orchestration (mod.rs)
- ComplianceService::check_address() runs KYC + AML in parallel (tokio::join!)
- process_trade_event() hooks into the event pipeline for trade_created events
- generate_report() for date-range compliance reporting
- review_check() for manual compliance override with reviewer attribution
- Risk score calculation combines KYC penalty + AML score (capped at 100)
- All checks persisted to DB for audit trail

## Monitoring Service (indexer/src/monitoring_service/)

Production-grade observability layer with Prometheus metrics, alert rules,
incident response integration, and a Grafana dashboard.

### Metrics Collection (metrics.rs)
- In-memory MetricsCollector with ring-buffer (last 10k points)
- Prometheus text format export via to_prometheus()
- Well-known metric name constants:
  stellar_escrow_events_processed_total
  stellar_escrow_trades_created/completed/disputed_total
  stellar_escrow_compliance_checks/blocked_total
  stellar_escrow_aml_high_risk_total
  stellar_escrow_fraud_alerts_total
  stellar_escrow_error_rate
  stellar_escrow_db_query_duration_ms
  stellar_escrow_api_request_duration_ms
  stellar_escrow_websocket_connections

### Alert Rules Engine (alerts.rs)
- AlertRule struct with metric name, threshold, operator (gt/gte/lt/lte),
  severity (Info/Warning/High/Critical), and message template
- evaluate_rule() produces AlertState with current value, threshold, message
- Default alert rules:
  - high_error_rate: error_rate > 5% → Critical
  - high_dispute_rate: disputes > 50 → High
  - compliance_blocks_spike: blocks > 10 → High
  - aml_high_risk_spike: high-risk > 5 → Critical
  - fraud_alerts_spike: fraud alerts > 20 → High
  
 closes #86 

### Dashboard (dashboard.rs)
- DashboardSummary with health status, alert counts, metrics snapshot,
  top 10 active alerts, and optional Grafana deep-link URL
- HealthStatus derived from active alerts: Healthy / Degraded / Critical

### Service (mod.rs)
- Background run_alert_loop() evaluates rules on configurable interval (default 30s)
- fire_alert() sends webhook payload to alert_webhook_url for High/Critical
- Critical alerts additionally POST to incident_webhook_url
  (PagerDuty/OpsGenie routing_key format)
- get_snapshot() returns full MonitoringSnapshot for dashboard endpoint

## API Endpoints

New routes registered in handlers.rs and main.rs:

  POST /compliance/check          — run KYC+AML check for an address
  GET  /compliance/status/:address — latest compliance status for an address
  POST /compliance/review          — manual review override with audit trail
  GET  /compliance/report          — generate report for a date range

  GET  /monitoring/dashboard       — full monitoring snapshot + health status
  GET  /monitoring/alerts          — list currently active alerts
  GET  /metrics                    — Prometheus text format metrics scrape endpoint

## Database

Migration: indexer/migrations/20260327000001_compliance.sql
- compliance_checks table with columns:
  id (UUID PK), address, trade_id, kyc_result (JSONB), aml_result (JSONB),
  status, risk_score (0–100), notes, checked_at, reviewed_by, reviewed_at
- Indexes on: address, trade_id, status, risk_score DESC, checked_at DESC

New Database methods:
  insert_compliance_check()
  get_latest_compliance_check(address)
  get_compliance_checks_in_range(from, to)
  update_compliance_review(check_id, status, reviewer, notes)

## Infrastructure (docker-compose.yml + monitoring/)

Prometheus
- Scrapes /metrics on indexer every 15s
- 30-day TSDB retention
- Loads alert_rules.yml with all platform alert rules
- Connected to Alertmanager

Grafana
- Auto-provisioned Prometheus + Loki datasources
- Pre-built StellarEscrow dashboard (stellar-escrow.json) with panels for:
  events processed, trades created, compliance checks, compliance blocked,
  AML high-risk, error rate gauge, fraud alerts, WebSocket connections
- Threshold-based color coding on compliance/AML panels

Loki + Promtail
- Loki for log aggregation (boltdb-shipper, filesystem storage)
- Promtail ships host logs + Docker container logs to Loki

Alertmanager
- Routes High → default webhook receiver
- Routes Critical → dedicated incident receiver (repeat every 1h)
- Inhibition rules: Critical suppresses High for same alertname

## Configuration

New sections added to config/base.toml:

  [compliance]
  kyc_provider_url, kyc_api_key
  aml_provider_url, aml_api_key
  required_kyc_level (default: 1)
  aml_risk_threshold (default: 70)
  blocked_jurisdictions (default: [])
  reporting_webhook_url

  [monitoring]
  metrics_port (default: 9090)
  alert_webhook_url
  grafana_url
  log_aggregation_url
  incident_webhook_url
  alert_eval_interval_secs (default: 30)

All values default to empty/disabled and are overridable via env vars:
  STELLAR_ESCROW__COMPLIANCE__KYC_API_KEY=...
  STELLAR_ESCROW__MONITORING__ALERT_WEBHOOK_URL=...

## AppState

compliance_service: Arc<ComplianceService> and
monitoring_service: Arc<MonitoringService> added to AppState in handlers.rs,
initialized and wired in main.rs with background alert loop spawned on startup.
