### PR TITLE
feature:Event Indexing Optimization

### DIFF
--- a/api/src/contracts.ts
+++ b/api/src/contracts.ts
@@ -38,11 +38,18 @@ export function isTrade(value: unknown): value is Trade {
   );
 }
 
+const EVENT_CATEGORIES = new Set<string>([
+  'trade', 'arb', 'fee', 'tmpl', 'sub', 'gov', 'sys', 'ins', 'oracle',
+]);
+
 export function isEvent(value: unknown): value is Event {
   return (
     isRecord(value) &&
     typeof value.id === 'string' &&
     typeof value.type === 'string' &&
+    typeof value.category === 'string' &&
+    EVENT_CATEGORIES.has(value.category) &&
+    typeof value.schemaVersion === 'number' &&
     typeof value.tradeId === 'string' &&
     typeof value.timestamp === 'string' &&
     isRecord(value.data)

--- a/api/src/models.ts
+++ b/api/src/models.ts
@@ -8,10 +8,41 @@ export interface Trade {
   timestamp: string;
 }
 
+/** High-level event categories matching the contract's topic layout. */
+export type EventCategory =
+  | 'trade'
+  | 'arb'
+  | 'fee'
+  | 'tmpl'
+  | 'sub'
+  | 'gov'
+  | 'sys'
+  | 'ins'
+  | 'oracle';
+
 export interface Event {
   id: string;
+  /** Canonical snake_case event name, e.g. "trade_created" */
   type: string;
+  /** High-level category for client-side filtering */
+  category: EventCategory;
+  /** Schema version from the contract payload (v field) */
+  schemaVersion: number;
   tradeId: string;
   timestamp: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
+}
+
+/** Query parameters accepted by GET /events */
+export interface EventFilterParams {
+  limit?: number;
+  offset?: number;
+  event_type?: string;
+  category?: EventCategory;
+  trade_id?: string;
+  from_ledger?: number;
+  to_ledger?: number;
+  from_time?: string;
+  to_time?: string;
+  contract_id?: string;
 }

--- a/api/src/resources.ts
+++ b/api/src/resources.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from './client';
-import { Event, Trade } from './models';
+import { Event, EventCategory, EventFilterParams, Trade } from './models';
 
 export class TradesApi {
   constructor(private client: ApiClient) {}
@@ -28,14 +28,27 @@ export class TradesApi {
 export class EventsApi {
   constructor(private client: ApiClient) {}
 
-  async getEvents(limit = 100, tradeId?: string): Promise<Event[]> {
-    const params = new URLSearchParams({ limit: limit.toString() });
-    if (tradeId) params.append('tradeId', tradeId);
+  async getEvents(filters: EventFilterParams = {}): Promise<Event[]> {
+    const params = new URLSearchParams();
+    if (filters.limit !== undefined) params.set('limit', filters.limit.toString());
+    if (filters.offset !== undefined) params.set('offset', filters.offset.toString());
+    if (filters.event_type) params.set('event_type', filters.event_type);
+    if (filters.category) params.set('category', filters.category);
+    if (filters.trade_id) params.set('trade_id', filters.trade_id);
+    if (filters.from_ledger !== undefined) params.set('from_ledger', filters.from_ledger.toString());
+    if (filters.to_ledger !== undefined) params.set('to_ledger', filters.to_ledger.toString());
+    if (filters.from_time) params.set('from_time', filters.from_time);
+    if (filters.to_time) params.set('to_time', filters.to_time);
+    if (filters.contract_id) params.set('contract_id', filters.contract_id);
     return this.client.get(`/events?${params}`);
   }
 
   async getEventsByTrade(tradeId: string): Promise<Event[]> {
     return this.client.get(`/events/trade/${tradeId}`);
+  }
+
+  async getEventsByCategory(category: EventCategory, limit = 50): Promise<Event[]> {
+    return this.getEvents({ category, limit });
   }
 
   async getEvent(id: string): Promise<Event> {

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -143,11 +143,11 @@ pub fn emit_trade_created(env: &Env, trade_id: u64, seller: Address, buyer: Addr
 }
 
 pub fn emit_compliance_failed(env: &Env, user: Address, reason: &soroban_sdk::String) {
-    env.events().publish((symbol_short!("compl_fail"),), (user, reason.clone()));
+    env.events().publish((cat_sys(), symbol_short!("compl_fail")), EvComplianceFailed { v: EVENT_VERSION, user, reason: reason.clone() });
 }
 
 pub fn emit_compliance_passed(env: &Env, trade_id: u64, seller: Address, buyer: Address, amount: u64) {
-    env.events().publish((symbol_short!("compl_pass"),), (trade_id, seller, buyer, amount));
+    env.events().publish((cat_sys(), symbol_short!("compl_pass")), EvCompliancePassed { v: EVENT_VERSION, trade_id, seller, buyer, amount });
 }
 
 pub fn emit_trade_funded(env: &Env, trade_id: u64) {
@@ -329,6 +329,19 @@ pub fn emit_oracle_price_fetched(env: &Env, base: Address, quote: Address, price
 pub fn emit_oracle_unavailable(env: &Env, base: Address, quote: Address) {
     env.events().publish((cat_oracle(), symbol_short!("orc_err")), EvOracleUnavailable { v: EVENT_VERSION, base, quote });
 }
+
+// ---------------------------------------------------------------------------
+// Upgrade system events
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Compliance event payloads
+// ---------------------------------------------------------------------------
+
+#[contracttype] #[derive(Clone, Debug)]
+pub struct EvComplianceFailed  { pub v: u32, pub user: Address, pub reason: String }
+#[contracttype] #[derive(Clone, Debug)]
+pub struct EvCompliancePassed  { pub v: u32, pub trade_id: u64, pub seller: Address, pub buyer: Address, pub amount: u64 }
 
 // ---------------------------------------------------------------------------
 // Upgrade system events

--- a/indexer/migrations/20260328000000_event_indexing_optimization.sql
+++ b/indexer/migrations/20260328000000_event_indexing_optimization.sql
@@ -1,0 +1,71 @@
+-- Event indexing optimization: add category, schema_version columns and supporting indexes.
+-- These columns are derived from the two-topic layout (category, event_name) emitted by the
+-- Soroban contract and enable efficient category-level filtering without JSON scanning.
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS category       VARCHAR(20)  NOT NULL DEFAULT 'unknown',
+    ADD COLUMN IF NOT EXISTS schema_version SMALLINT     NOT NULL DEFAULT 1;
+
+-- Backfill category from event_type for existing rows
+UPDATE events SET category = CASE
+    WHEN event_type IN (
+        'trade_created', 'trade_funded', 'trade_completed', 'trade_confirmed',
+        'trade_cancelled', 'time_released', 'metadata_updated',
+        'dispute_raised', 'dispute_resolved', 'partial_resolved'
+    ) THEN 'trade'
+    WHEN event_type IN (
+        'arbitrator_registered', 'arbitrator_removed',
+        'arbitrator_rated', 'arbitrator_rep_updated'
+    ) THEN 'arb'
+    WHEN event_type IN (
+        'fee_updated', 'fees_withdrawn', 'fees_distributed', 'custom_fee_set',
+        'tier_upgraded', 'tier_downgraded', 'tier_config_updated'
+    ) THEN 'fee'
+    WHEN event_type IN (
+        'template_created', 'template_updated', 'template_deactivated', 'template_trade'
+    ) THEN 'tmpl'
+    WHEN event_type IN (
+        'subscribed', 'subscription_renewed', 'subscription_cancelled'
+    ) THEN 'sub'
+    WHEN event_type IN (
+        'proposal_created', 'vote_cast', 'proposal_executed', 'delegated'
+    ) THEN 'gov'
+    WHEN event_type IN (
+        'insurance_provider_registered', 'insurance_provider_removed',
+        'insurance_purchased', 'insurance_claimed'
+    ) THEN 'ins'
+    WHEN event_type IN (
+        'oracle_registered', 'oracle_removed',
+        'oracle_price_fetched', 'oracle_unavailable'
+    ) THEN 'oracle'
+    ELSE 'sys'
+END
+WHERE category = 'unknown';
+
+-- Backfill schema_version from the JSON payload where available
+UPDATE events
+SET schema_version = (data->>'v')::SMALLINT
+WHERE data->>'v' IS NOT NULL
+  AND (data->>'v') ~ '^\d+$';
+
+-- Indexes for the new columns
+CREATE INDEX IF NOT EXISTS idx_events_category
+    ON events (category);
+
+CREATE INDEX IF NOT EXISTS idx_events_category_ledger
+    ON events (category, ledger DESC);
+
+CREATE INDEX IF NOT EXISTS idx_events_schema_version
+    ON events (schema_version);
+
+-- Composite index for the most common query pattern: category + event_type + ledger range
+CREATE INDEX IF NOT EXISTS idx_events_category_type_ledger
+    ON events (category, event_type, ledger DESC);
+
+-- Timestamp range index (already exists in initial migration, kept for reference)
+-- CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events (timestamp DESC);
+
+-- Partial index for trade events (highest query volume)
+CREATE INDEX IF NOT EXISTS idx_events_trade_category
+    ON events (ledger DESC, timestamp DESC)
+    WHERE category = 'trade';

--- a/indexer/src/database.rs
+++ b/indexer/src/database.rs
@@ -58,13 +58,15 @@ impl Database {
     pub async fn insert_event(&self, event: &Event) -> Result<(), AppError> {
         sqlx::query(
             r#"
-            INSERT INTO events (id, event_type, contract_id, ledger, transaction_hash, timestamp, data, created_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO events (id, event_type, category, schema_version, contract_id, ledger, transaction_hash, timestamp, data, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (id) DO NOTHING
             "#,
         )
         .bind(event.id)
         .bind(&event.event_type)
+        .bind(&event.category)
+        .bind(event.schema_version)
         .bind(&event.contract_id)
         .bind(event.ledger)
         .bind(&event.transaction_hash)
@@ -77,13 +79,64 @@ impl Database {
         Ok(())
     }
 
+    /// Batch-insert up to `events.len()` events in a single transaction.
+    /// Conflicts on `id` are silently skipped (idempotent replay).
+    pub async fn insert_events_batch(&self, events: &[Event]) -> Result<crate::models::BatchInsertResult, AppError> {
+        if events.is_empty() {
+            return Ok(crate::models::BatchInsertResult { inserted: 0, skipped: 0 });
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let mut inserted = 0usize;
+
+        for event in events {
+            let result = sqlx::query(
+                r#"
+                INSERT INTO events (id, event_type, category, schema_version, contract_id, ledger, transaction_hash, timestamp, data, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                ON CONFLICT (id) DO NOTHING
+                "#,
+            )
+            .bind(event.id)
+            .bind(&event.event_type)
+            .bind(&event.category)
+            .bind(event.schema_version)
+            .bind(&event.contract_id)
+            .bind(event.ledger)
+            .bind(&event.transaction_hash)
+            .bind(event.timestamp)
+            .bind(&event.data)
+            .bind(event.created_at)
+            .execute(&mut *tx)
+            .await?;
+
+            if result.rows_affected() > 0 {
+                inserted += 1;
+            }
+        }
+
+        tx.commit().await?;
+        let skipped = events.len() - inserted;
+        Ok(crate::models::BatchInsertResult { inserted, skipped })
+    }
+
     pub async fn get_events(&self, query: &EventQuery) -> Result<Vec<Event>, AppError> {
-        let mut sql = "SELECT id, event_type, contract_id, ledger, transaction_hash, timestamp, data, created_at FROM events WHERE 1=1".to_string();
+        let mut sql = "SELECT id, event_type, category, schema_version, contract_id, ledger, transaction_hash, timestamp, data, created_at FROM events WHERE 1=1".to_string();
         let mut owned: Vec<String> = vec![];
 
         if let Some(event_type) = &query.event_type {
             sql.push_str(&format!(" AND event_type = ${}", owned.len() + 1));
             owned.push(event_type.clone());
+        }
+
+        if let Some(category) = &query.category {
+            sql.push_str(&format!(" AND category = ${}", owned.len() + 1));
+            owned.push(category.clone());
+        }
+
+        if let Some(contract_id) = &query.contract_id {
+            sql.push_str(&format!(" AND contract_id = ${}", owned.len() + 1));
+            owned.push(contract_id.clone());
         }
 
         if let Some(trade_id) = query.trade_id {
@@ -101,6 +154,17 @@ impl Database {
             owned.push(to_ledger.to_string());
         }
 
+        // Timestamp range filters use positional params bound separately below
+        let mut time_params: Vec<chrono::DateTime<chrono::Utc>> = vec![];
+        if let Some(from_time) = query.from_time {
+            sql.push_str(&format!(" AND timestamp >= ${}", owned.len() + time_params.len() + 1));
+            time_params.push(from_time);
+        }
+        if let Some(to_time) = query.to_time {
+            sql.push_str(&format!(" AND timestamp <= ${}", owned.len() + time_params.len() + 1));
+            time_params.push(to_time);
+        }
+
         sql.push_str(" ORDER BY ledger DESC, timestamp DESC");
 
         if let Some(limit) = query.limit {
@@ -112,9 +176,11 @@ impl Database {
         }
 
         let mut query_builder = sqlx::query(&sql);
-
         for s in &owned {
             query_builder = query_builder.bind(s.as_str());
+        }
+        for t in &time_params {
+            query_builder = query_builder.bind(*t);
         }
 
         let rows = query_builder.fetch_all(&self.pool).await?;
@@ -124,6 +190,8 @@ impl Database {
             .map(|row| Event {
                 id: row.get("id"),
                 event_type: row.get("event_type"),
+                category: row.get("category"),
+                schema_version: row.get("schema_version"),
                 contract_id: row.get("contract_id"),
                 ledger: row.get("ledger"),
                 transaction_hash: row.get("transaction_hash"),
@@ -139,7 +207,7 @@ impl Database {
     pub async fn get_event_by_id(&self, id: Uuid) -> Result<Event, AppError> {
         let row = sqlx::query(
             r#"
-            SELECT id, event_type, contract_id, ledger, transaction_hash, timestamp, data, created_at
+            SELECT id, event_type, category, schema_version, contract_id, ledger, transaction_hash, timestamp, data, created_at
             FROM events WHERE id = $1
             "#,
         )
@@ -151,6 +219,8 @@ impl Database {
         Ok(Event {
             id: row.get("id"),
             event_type: row.get("event_type"),
+            category: row.get("category"),
+            schema_version: row.get("schema_version"),
             contract_id: row.get("contract_id"),
             ledger: row.get("ledger"),
             transaction_hash: row.get("transaction_hash"),
@@ -181,6 +251,14 @@ impl Database {
             sql.push_str(&format!(" AND event_type = ${}", bindings.len() + 1));
             bindings.push(event_type.clone());
         }
+        if let Some(category) = &query.category {
+            sql.push_str(&format!(" AND category = ${}", bindings.len() + 1));
+            bindings.push(category.clone());
+        }
+        if let Some(contract_id) = &query.contract_id {
+            sql.push_str(&format!(" AND contract_id = ${}", bindings.len() + 1));
+            bindings.push(contract_id.clone());
+        }
         if let Some(trade_id) = query.trade_id {
             sql.push_str(&format!(" AND data->>'trade_id' = ${}", bindings.len() + 1));
             bindings.push(trade_id.to_string());
@@ -198,6 +276,16 @@ impl Database {
         for b in &bindings {
             q = q.bind(b);
         }
+        // Timestamp filters bound separately (DateTime type)
+        if let Some(from_time) = query.from_time {
+            sql.push_str(&format!(" AND timestamp >= ${}", bindings.len() + 1));
+            q = q.bind(from_time);
+        }
+        if let Some(to_time) = query.to_time {
+            sql.push_str(&format!(" AND timestamp <= ${}", bindings.len() + 1));
+            q = q.bind(to_time);
+        }
+
         let row = q.fetch_one(&self.pool).await?;
         Ok(row.get::<i64, _>(0))
     }
@@ -210,7 +298,7 @@ impl Database {
     ) -> Result<Vec<Event>, AppError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, event_type, contract_id, ledger, transaction_hash, timestamp, data, created_at
+            SELECT id, event_type, category, schema_version, contract_id, ledger, transaction_hash, timestamp, data, created_at
             FROM events
             WHERE contract_id = $1 AND ledger >= $2 AND ledger <= $3
             ORDER BY ledger ASC, timestamp ASC
@@ -227,6 +315,8 @@ impl Database {
             .map(|row| Event {
                 id: row.get("id"),
                 event_type: row.get("event_type"),
+                category: row.get("category"),
+                schema_version: row.get("schema_version"),
                 contract_id: row.get("contract_id"),
                 ledger: row.get("ledger"),
                 transaction_hash: row.get("transaction_hash"),

--- a/indexer/src/event_monitor.rs
+++ b/indexer/src/event_monitor.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use futures::stream::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +14,10 @@ use crate::job_queue::{JobQueue, types::{Job, JobType}};
 use crate::models::{Event, WebSocketMessage};
 use crate::websocket::WebSocketManager;
 
+// ---------------------------------------------------------------------------
+// Horizon API response types
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Deserialize)]
 struct HorizonResponse<T> {
     _embedded: EmbeddedRecords<T>,
@@ -29,7 +32,6 @@ struct EmbeddedRecords<T> {
 #[derive(Debug, Deserialize)]
 struct Links {
     next: Option<Link>,
-    prev: Option<Link>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -40,9 +42,9 @@ struct Link {
 #[derive(Debug, Deserialize)]
 struct Ledger {
     sequence: i64,
-    closed_at: String,
 }
 
+/// Raw contract effect from Horizon.
 #[derive(Debug, Deserialize)]
 struct Effect {
     id: String,
@@ -50,9 +52,104 @@ struct Effect {
     effect_type: String,
     created_at: String,
     contract: Option<String>,
+    /// topics[0] = category symbol, topics[1] = event_name symbol
     topics: Vec<String>,
     data: serde_json::Value,
 }
+
+// ---------------------------------------------------------------------------
+// Topic → (category, event_type) mapping
+// ---------------------------------------------------------------------------
+
+/// Derive the canonical event_type string and its category from the two-topic
+/// layout emitted by the contract: `(category, event_name)`.
+///
+/// Returns `None` for unknown/unhandled combinations so the caller can skip them.
+fn resolve_event_type(category: &str, event_name: &str) -> Option<(&'static str, &'static str)> {
+    match (category, event_name) {
+        // trade category
+        ("trade", "created")   => Some(("trade", "trade_created")),
+        ("trade", "funded")    => Some(("trade", "trade_funded")),
+        ("trade", "complete")  => Some(("trade", "trade_completed")),
+        ("trade", "confirm")   => Some(("trade", "trade_confirmed")),
+        ("trade", "cancel")    => Some(("trade", "trade_cancelled")),
+        ("trade", "time_rel")  => Some(("trade", "time_released")),
+        ("trade", "meta_upd")  => Some(("trade", "metadata_updated")),
+        ("trade", "dispute")   => Some(("trade", "dispute_raised")),
+        ("trade", "resolved")  => Some(("trade", "dispute_resolved")),
+        ("trade", "part_res")  => Some(("trade", "partial_resolved")),
+        // arb category
+        ("arb", "arb_reg")     => Some(("arb", "arbitrator_registered")),
+        ("arb", "arb_rem")     => Some(("arb", "arbitrator_removed")),
+        ("arb", "arb_rate")    => Some(("arb", "arbitrator_rated")),
+        ("arb", "arb_rep")     => Some(("arb", "arbitrator_rep_updated")),
+        // fee category
+        ("fee", "fee_upd")     => Some(("fee", "fee_updated")),
+        ("fee", "fees_out")    => Some(("fee", "fees_withdrawn")),
+        ("fee", "fee_dst")     => Some(("fee", "fees_distributed")),
+        ("fee", "cust_fee")    => Some(("fee", "custom_fee_set")),
+        ("fee", "tier_up")     => Some(("fee", "tier_upgraded")),
+        ("fee", "tier_dn")     => Some(("fee", "tier_downgraded")),
+        ("fee", "tier_cfg")    => Some(("fee", "tier_config_updated")),
+        // tmpl category
+        ("tmpl", "tmpl_cr")    => Some(("tmpl", "template_created")),
+        ("tmpl", "tmpl_up")    => Some(("tmpl", "template_updated")),
+        ("tmpl", "tmpl_off")   => Some(("tmpl", "template_deactivated")),
+        ("tmpl", "tmpl_tr")    => Some(("tmpl", "template_trade")),
+        // sub category
+        ("sub", "sub_new")     => Some(("sub", "subscribed")),
+        ("sub", "sub_ren")     => Some(("sub", "subscription_renewed")),
+        ("sub", "sub_can")     => Some(("sub", "subscription_cancelled")),
+        // gov category
+        ("gov", "prop_cr")     => Some(("gov", "proposal_created")),
+        ("gov", "voted")       => Some(("gov", "vote_cast")),
+        ("gov", "prop_ex")     => Some(("gov", "proposal_executed")),
+        ("gov", "delegat")     => Some(("gov", "delegated")),
+        // sys category
+        ("sys", "paused")      => Some(("sys", "paused")),
+        ("sys", "unpaused")    => Some(("sys", "unpaused")),
+        ("sys", "emrg_wd")     => Some(("sys", "emergency_withdraw")),
+        ("sys", "upgraded")    => Some(("sys", "upgraded")),
+        ("sys", "migrated")    => Some(("sys", "migrated")),
+        ("sys", "priv_set")    => Some(("sys", "privacy_set")),
+        ("sys", "disc_gr")     => Some(("sys", "disclosure_granted")),
+        ("sys", "disc_rv")     => Some(("sys", "disclosure_revoked")),
+        ("sys", "brg_set")     => Some(("sys", "bridge_oracle_set")),
+        ("sys", "brg_cr")      => Some(("sys", "bridge_trade_created")),
+        ("sys", "brg_ok")      => Some(("sys", "bridge_deposit_confirmed")),
+        ("sys", "brg_exp")     => Some(("sys", "bridge_trade_expired")),
+        ("sys", "compl_fail")  => Some(("sys", "compliance_failed")),
+        ("sys", "compl_pass")  => Some(("sys", "compliance_passed")),
+        ("sys", "up_prop")     => Some(("sys", "upgrade_proposed")),
+        ("sys", "up_can")      => Some(("sys", "upgrade_cancelled")),
+        ("sys", "up_rb")       => Some(("sys", "upgrade_rolled_back")),
+        // ins category
+        ("ins", "ins_reg")     => Some(("ins", "insurance_provider_registered")),
+        ("ins", "ins_rem")     => Some(("ins", "insurance_provider_removed")),
+        ("ins", "ins_buy")     => Some(("ins", "insurance_purchased")),
+        ("ins", "ins_pay")     => Some(("ins", "insurance_claimed")),
+        // oracle category
+        ("oracle", "orc_reg")  => Some(("oracle", "oracle_registered")),
+        ("oracle", "orc_rem")  => Some(("oracle", "oracle_removed")),
+        ("oracle", "orc_px")   => Some(("oracle", "oracle_price_fetched")),
+        ("oracle", "orc_err")  => Some(("oracle", "oracle_unavailable")),
+        _ => None,
+    }
+}
+
+/// Extract the schema version from the event data payload (`v` field).
+fn extract_schema_version(data: &serde_json::Value) -> i32 {
+    data.get("v")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(1) as i32
+}
+
+// ---------------------------------------------------------------------------
+// EventMonitor
+// ---------------------------------------------------------------------------
+
+/// How many effects to accumulate before flushing to the database.
+const BATCH_SIZE: usize = 50;
 
 pub struct EventMonitor {
     config: StellarConfig,
@@ -95,7 +192,6 @@ impl EventMonitor {
             self.config.contract_id
         );
 
-        // Get the latest ledger from database if not specified in config
         if self.last_ledger.is_none() {
             match self
                 .database
@@ -116,18 +212,16 @@ impl EventMonitor {
             if let Err(e) = self.poll_events().await {
                 error!("Error polling events: {}", e);
             }
-
             sleep(Duration::from_secs(self.config.poll_interval_seconds)).await;
         }
     }
 
     async fn poll_events(&mut self) -> Result<(), AppError> {
-        // Get latest ledger
         let latest_ledger = self.get_latest_ledger().await?;
-        let start_ledger = self.last_ledger.unwrap_or(latest_ledger - 100); // Look back 100 ledgers if no start point
+        let start_ledger = self.last_ledger.unwrap_or(latest_ledger - 100);
 
         if start_ledger >= latest_ledger {
-            return Ok(()); // No new ledgers
+            return Ok(());
         }
 
         info!(
@@ -135,71 +229,99 @@ impl EventMonitor {
             start_ledger, latest_ledger
         );
 
-        // Get effects for the contract
         let effects = self
             .get_contract_effects(start_ledger, latest_ledger)
             .await?;
 
+        // Parse all effects into structured events first
+        let mut batch: Vec<Event> = Vec::with_capacity(effects.len());
         for effect in effects {
             if let Some(event) = self.parse_effect_to_event(effect).await? {
-                // Broadcast to WebSocket clients
-                let ws_message = WebSocketMessage {
-                    event_type: event.event_type.clone(),
-                    data: event.data.clone(),
-                    timestamp: event.timestamp,
-                };
-                self.ws_manager.broadcast(ws_message).await;
+                batch.push(event);
+            }
+        }
 
-                // Process fraud detection
-                let report = if event.event_type == "trade_created" {
-                    self.fraud_service.process_event(&event).await
-                } else if event.event_type == "trade_confirmed" {
-                    self.fraud_service.process_confirmed_event(&event).await
-                } else {
-                    None
-                };
-
-                if let Some(report) = report {
-                    if let Err(e) = self.database.insert_fraud_alert(&report).await {
-                        error!("Error inserting fraud alert: {}", e);
-                    }
-                    if report.status == "high_risk" {
-                        warn!("!!! HIGH RISK TRANSACTION DETECTED !!!");
-                        warn!("Trade ID: {}", report.trade_id);
-                        warn!("Score: {}/100", report.risk_score);
-                        warn!("Rules: {:?}", report.rules_triggered);
-
-                        // Emit a special "fraud_alert" websocket message for real-time dashboard updates
-                        self.ws_manager
-                            .broadcast(WebSocketMessage {
-                                event_type: "fraud_alert".to_string(),
-                                data: serde_json::to_value(&report).unwrap_or_default(),
-                                timestamp: Utc::now(),
-                            })
-                            .await;
-                    }
+        // Flush in chunks to avoid oversized transactions
+        for chunk in batch.chunks(BATCH_SIZE) {
+            match self.database.insert_events_batch(chunk).await {
+                Ok(result) => {
+                    info!(
+                        "Batch inserted {} events ({} skipped as duplicates)",
+                        result.inserted, result.skipped
+                    );
                 }
-
-                // Enqueue background job for event processing
-                let job = Job {
-                    job_type: JobType::Event,
-                    event_id: event.id.to_string(),
-                    trade_id: event.data.get("trade_id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown")
-                        .to_string(),
-                    payload: event.data.clone(),
-                };
-                
-                let mut queue = self.job_queue.lock().await;
-                if let Err(e) = queue.enqueue(job).await {
-                    error!("Failed to enqueue job: {}", e);
+                Err(e) => {
+                    error!("Batch insert failed: {}", e);
                 }
+            }
+
+            // Post-insert processing per event
+            for event in chunk {
+                self.process_event(event).await;
             }
         }
 
         self.last_ledger = Some(latest_ledger);
         Ok(())
+    }
+
+    /// Run fraud detection, WebSocket broadcast, and job enqueue for a single event.
+    async fn process_event(&self, event: &Event) {
+        // Broadcast to WebSocket subscribers with structured metadata
+        let ws_message = WebSocketMessage {
+            event_type: event.event_type.clone(),
+            category: event.category.clone(),
+            version: event.schema_version as u32,
+            data: event.data.clone(),
+            timestamp: event.timestamp,
+        };
+        self.ws_manager.broadcast(ws_message).await;
+
+        // Fraud detection for high-value trade events
+        let report = match event.event_type.as_str() {
+            "trade_created" => self.fraud_service.process_event(event).await,
+            "trade_confirmed" => self.fraud_service.process_confirmed_event(event).await,
+            _ => None,
+        };
+
+        if let Some(report) = report {
+            if let Err(e) = self.database.insert_fraud_alert(&report).await {
+                error!("Error inserting fraud alert: {}", e);
+            }
+            if report.status == "high_risk" {
+                warn!(
+                    "HIGH RISK TRANSACTION: trade_id={} score={}/100 rules={:?}",
+                    report.trade_id, report.risk_score, report.rules_triggered
+                );
+                self.ws_manager
+                    .broadcast(WebSocketMessage {
+                        event_type: "fraud_alert".to_string(),
+                        category: "sys".to_string(),
+                        version: 0,
+                        data: serde_json::to_value(&report).unwrap_or_default(),
+                        timestamp: Utc::now(),
+                    })
+                    .await;
+            }
+        }
+
+        // Enqueue background job
+        let job = Job {
+            job_type: JobType::Event,
+            event_id: event.id.to_string(),
+            trade_id: event
+                .data
+                .get("trade_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            payload: event.data.clone(),
+        };
+
+        let mut queue = self.job_queue.lock().await;
+        if let Err(e) = queue.enqueue(job).await {
+            error!("Failed to enqueue job for event {}: {}", event.id, e);
+        }
     }
 
     async fn get_latest_ledger(&self) -> Result<i64, AppError> {
@@ -214,11 +336,11 @@ impl EventMonitor {
         to_ledger: i64,
     ) -> Result<Vec<Effect>, AppError> {
         let mut all_effects = Vec::new();
-        let mut cursor = None;
+        let mut cursor: Option<String> = None;
 
         loop {
             let mut url = format!(
-                "{}/effects?contract={}&ledger.ge={}&ledger.le={}",
+                "{}/effects?contract={}&ledger.ge={}&ledger.le={}&limit=200",
                 self.config.horizon_url, self.config.contract_id, from_ledger, to_ledger
             );
 
@@ -229,14 +351,13 @@ impl EventMonitor {
             let response: HorizonResponse<Effect> =
                 self.client.get(&url).send().await?.json().await?;
 
-            let next = response._links.next.is_none();
+            let has_next = response._links.next.is_some();
             let last_id = response._embedded.records.last().map(|r| r.id.clone());
             all_effects.extend(response._embedded.records);
 
-            if next {
+            if !has_next {
                 break;
             }
-
             cursor = last_id;
         }
 
@@ -244,73 +365,62 @@ impl EventMonitor {
     }
 
     async fn parse_effect_to_event(&self, effect: Effect) -> Result<Option<Event>, AppError> {
-        // Only process contract events
         if effect.contract.as_ref() != Some(&self.config.contract_id) {
             return Ok(None);
         }
 
-        // Parse topics to determine event type
-        if effect.topics.is_empty() {
+        // Contract events use a two-topic layout: (category, event_name)
+        if effect.topics.len() < 2 {
             return Ok(None);
         }
 
-        let event_type = match effect.topics[0].as_str() {
-            "created" => "trade_created",
-            "funded" => "trade_funded",
-            "complete" => "trade_completed",
-            "confirm" => "trade_confirmed",
-            "dispute" => "dispute_raised",
-            "resolved" => "dispute_resolved",
-            "cancel" => "trade_cancelled",
-            "arb_reg" => "arbitrator_registered",
-            "arb_rem" => "arbitrator_removed",
-            "fee_upd" => "fee_updated",
-            "fees_out" => "fees_withdrawn",
-            _ => return Ok(None), // Unknown event type
+        let category_raw = &effect.topics[0];
+        let event_name_raw = &effect.topics[1];
+
+        let (category, event_type) = match resolve_event_type(category_raw, event_name_raw) {
+            Some(pair) => pair,
+            None => {
+                // Log unknown events at debug level rather than silently dropping
+                tracing::debug!(
+                    "Unhandled event topic ({}, {}), skipping",
+                    category_raw,
+                    event_name_raw
+                );
+                return Ok(None);
+            }
         };
 
-        // Parse timestamp
         let timestamp = DateTime::parse_from_rfc3339(&effect.created_at)
             .map_err(|e| AppError::InvalidEventData(format!("Invalid timestamp: {}", e)))?
             .with_timezone(&Utc);
 
-        // Get ledger from effect ID (effects are ordered by ledger)
         let ledger = self.extract_ledger_from_effect_id(&effect.id)?;
-
-        // Get transaction hash from effect
         let transaction_hash = self.get_transaction_hash_for_effect(&effect.id).await?;
+        let schema_version = extract_schema_version(&effect.data);
 
-        let event = Event {
+        Ok(Some(Event {
             id: Uuid::new_v4(),
             event_type: event_type.to_string(),
+            category: category.to_string(),
+            schema_version,
             contract_id: self.config.contract_id.clone(),
             ledger,
             transaction_hash,
             timestamp,
             data: effect.data,
             created_at: Utc::now(),
-        };
-
-        Ok(Some(event))
+        }))
     }
 
     fn extract_ledger_from_effect_id(&self, effect_id: &str) -> Result<i64, AppError> {
-        // Effect IDs are in format: <ledger>-<transaction>-<operation>-<effect>
-        let parts: Vec<&str> = effect_id.split('-').collect();
-        if parts.len() < 1 {
-            return Err(AppError::InvalidEventData(
-                "Invalid effect ID format".to_string(),
-            ));
-        }
-
-        parts[0]
-            .parse()
-            .map_err(|_| AppError::InvalidEventData("Invalid ledger in effect ID".to_string()))
+        effect_id
+            .split('-')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| AppError::InvalidEventData("Invalid effect ID format".to_string()))
     }
 
     async fn get_transaction_hash_for_effect(&self, effect_id: &str) -> Result<String, AppError> {
-        // For simplicity, we'll use the effect ID as transaction hash
-        // In a real implementation, you'd query the effect's transaction
         Ok(effect_id.to_string())
     }
 }

--- a/indexer/src/fraud_service/test.rs
+++ b/indexer/src/fraud_service/test.rs
@@ -14,6 +14,8 @@ mod tests {
         Event {
             id: Uuid::new_v4(),
             event_type: event_type.to_string(),
+            category: "trade".to_string(),
+            schema_version: 2,
             contract_id: "test_contract".to_string(),
             ledger: 1000,
             transaction_hash: "test_hash".to_string(),

--- a/indexer/src/handlers.rs
+++ b/indexer/src/handlers.rs
@@ -188,6 +188,8 @@ pub async fn replay_events(
     for event in &events {
         let ws_message = WebSocketMessage {
             event_type: event.event_type.clone(),
+            category: event.category.clone(),
+            version: event.schema_version as u32,
             data: event.data.clone(),
             timestamp: event.timestamp,
         };

--- a/indexer/src/integration_service/test.rs
+++ b/indexer/src/integration_service/test.rs
@@ -14,6 +14,8 @@ mod tests {
         Event {
             id: Uuid::new_v4(),
             event_type: event_type.to_string(),
+            category: "trade".to_string(),
+            schema_version: 2,
             contract_id: "CTEST".to_string(),
             ledger: 1000,
             transaction_hash: "abc123".to_string(),

--- a/indexer/src/models.rs
+++ b/indexer/src/models.rs
@@ -7,6 +7,10 @@ use uuid::Uuid;
 pub struct Event {
     pub id: Uuid,
     pub event_type: String,
+    /// High-level category (trade / arb / fee / tmpl / sub / gov / sys / ins / oracle)
+    pub category: String,
+    /// Schema version from the contract event payload (v field)
+    pub schema_version: i32,
     pub contract_id: String,
     pub ledger: i64,
     pub transaction_hash: String,
@@ -84,9 +88,17 @@ pub struct EventQuery {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
     pub event_type: Option<String>,
+    /// Filter by event category (e.g. "trade", "arb", "fee", "gov", "sys", "ins", "oracle")
+    pub category: Option<String>,
     pub trade_id: Option<u64>,
     pub from_ledger: Option<i64>,
     pub to_ledger: Option<i64>,
+    /// ISO-8601 lower bound on event timestamp
+    pub from_time: Option<chrono::DateTime<Utc>>,
+    /// ISO-8601 upper bound on event timestamp
+    pub to_time: Option<chrono::DateTime<Utc>>,
+    /// Filter by contract address
+    pub contract_id: Option<String>,
 }
 
 /// Paginated response wrapper for list endpoints.
@@ -99,6 +111,13 @@ pub struct PagedResponse<T: Serialize> {
     pub has_more: bool,
 }
 
+/// Result of a batch event insert operation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchInsertResult {
+    pub inserted: usize,
+    pub skipped: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReplayRequest {
     pub from_ledger: i64,
@@ -108,6 +127,10 @@ pub struct ReplayRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebSocketMessage {
     pub event_type: String,
+    /// Event category (e.g. "trade", "arb", "fee") — enables client-side filtering
+    pub category: String,
+    /// Schema version from the contract event payload
+    pub version: u32,
     pub data: serde_json::Value,
     pub timestamp: DateTime<Utc>,
 }


### PR DESCRIPTION
closes #225


# StellarEscrow — Performance Optimization

## Bottleneck Analysis

Run the analysis script to identify current bottlenecks:

```bash
./scripts/perf-analyze.sh          # human-readable
./scripts/perf-analyze.sh --json   # JSON output for dashboards
```

The script checks:
1. **Slow queries** — `pg_stat_statements` top 10 by mean execution time
2. **Index usage** — tables with low index-scan ratio (candidates for new indexes)
3. **API latency** — live data from `/health/metrics`
4. **Container resources** — CPU/memory via `docker stats`
5. **Redis hit rate** — `keyspace_hits` vs `keyspace_misses`

---

## Caching Strategy

### Redis API Cache (`indexer/src/cache.rs`)

| Endpoint pattern | TTL | Rationale |
|-----------------|-----|-----------|
| `GET /events*` | 10s | High-frequency reads; Stellar ledger closes every ~5s |
| `GET /search*` | 30s | Search results change infrequently |
| `GET /stats` | 60s | Aggregate — expensive to compute |
| `POST /events/replay` | no cache | Mutating |

**Activate:** set `redis_url` in `config.toml` or `REDIS_URL` env var.  
**Fallback:** if Redis is unavailable, all requests hit Postgres directly — no errors.

### Client-Side Cache (`frontend/performance.js`)

`cachedFetch()` provides an in-memory TTL cache (default 30s) for API responses.  
Call `invalidateCache(url)` after any write operation to keep the UI consistent.

### CDN / HTTP Cache (`cdn-headers.nginx.conf`)

| Asset type | Cache-Control |
|-----------|--------------|
| Hashed JS/CSS | `immutable, max-age=31536000` |
| Images/fonts | `max-age=86400, stale-while-revalidate=3600` |
| HTML/JSON | `max-age=300` |
| Service worker | `no-store` |

---

## Resource Allocation

### Database Connection Pool

Configured in `indexer/config.toml`:

```toml
[database]
max_connections = 10   # increase for high-concurrency deployments
min_connections = 2    # keep warm connections ready
```

**Rule of thumb:** `max_connections = (2 × CPU cores) + effective_spindle_count`  
For a 4-core host: set `max_connections = 10–15`.

### Nginx (`performance.nginx.conf`)

- `worker_processes auto` — one worker per CPU core
- `worker_connections 4096` — handles ~4k concurrent connections per worker
- `keepalive 32` on the upstream pool — reuses TCP connections to the Rust indexer
- `gzip` on for JS/CSS/JSON — typically 60–80% size reduction

### Docker Resource Limits

Add to `docker-compose.yml` services for production:

```yaml
deploy:
  resources:
    limits:
      cpus: '1.0'
      memory: 512M
    reservations:
      cpus: '0.25'
      memory: 128M
```

---

## Performance Monitoring

Metrics are collected at three layers:

| Layer | Mechanism | Endpoint |
|-------|-----------|---------|
| Infrastructure | `HealthMonitor` (Rust) | `GET /health/metrics` |
| Web Vitals | `observeWebVitals()` (JS) | beacons → `POST /api/metrics` |
| CDN | `observeCdnPerformance()` (JS) | beacons → `POST /api/metrics` |
| SSL | `monitorTlsConnection()` (JS) | beacons → `POST /api/metrics` |

### Key Metrics to Watch

- **TTFB** < 200ms (good), < 800ms (acceptable)
- **LCP** < 2.5s
- **DB query mean** < 10ms for hot paths (`get_events`, `search_trades`)
- **Redis hit rate** > 80% under normal load
- **Indexer memory** < 256MB under normal load

---

## Quick Wins Checklist

- [ ] Enable Redis (`redis_url` in config) — eliminates repeat DB hits for read-heavy endpoints
- [ ] Enable `pg_stat_statements` extension — required for slow query analysis
- [ ] Set `max_connections` based on actual CPU count
- [ ] Include `performance.nginx.conf` in nginx http block
- [ ] Add `REDIS_URL` to docker-compose environment
- [ ] Run `perf-analyze.sh` weekly and track trends
