### PR TITLE
feat: wire on-chain analytics hooks for issue #235

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -541,6 +541,7 @@ impl StellarEscrowContract {
         save_trade(&env, trade_id, &trade);
         events::emit_trade_created(&env, trade_id, seller.clone(), buyer.clone(), amount);
         events::emit_compliance_passed(&env, trade_id, seller, buyer, amount);
+        analytics::on_trade_created(&env, amount, &trade.seller, &trade.buyer);
         Ok(trade_id)
     }
 
@@ -827,8 +828,19 @@ impl StellarEscrowContract {
                 }
                 save_arbitrator_reputation(&env, arbitrator, &rep);
                 events::emit_arb_rep_updated(&env, arbitrator.clone(), rep.resolved_count, rep.rating_sum, rep.rating_count);
+                let resolution_code: u8 = match resolution {
+                    DisputeResolution::ReleaseToBuyer => 0,
+                    DisputeResolution::ReleaseToSeller => 1,
+                    DisputeResolution::Partial { .. } => 2,
+                };
+                analytics::on_dispute_resolved(&env, arbitrator, resolution_code);
             }
             Some(ArbitrationConfig::MultiSig(config)) => {
+                let resolution_code: u8 = match resolution {
+                    DisputeResolution::ReleaseToBuyer => 0,
+                    DisputeResolution::ReleaseToSeller => 1,
+                    DisputeResolution::Partial { .. } => 2,
+                };
                 for i in 0..config.arbitrators.len() {
                     let arb = config.arbitrators.get(i).unwrap();
                     let mut rep = storage::get_arbitrator_reputation(&env, arb);
@@ -840,28 +852,17 @@ impl StellarEscrowContract {
                     }
                     save_arbitrator_reputation(&env, arb, &rep);
                     events::emit_arb_rep_updated(&env, arb.clone(), rep.resolved_count, rep.rating_sum, rep.rating_count);
+                    analytics::on_dispute_resolved(&env, &arb, resolution_code);
                 }
                 // Clear votes after resolution
                 storage::clear_votes_for_trade(&env, trade_id, &config.arbitrators);
             }
             None => {}
         }
-        save_arbitrator_reputation(&env, &arbitrator, &rep);
-        events::emit_arb_rep_updated(&env, arbitrator.clone(), rep.resolved_count, rep.rating_sum, rep.rating_count);
-        set_currency_fees(&env, &trade.currency, new_fees);
-        let token = get_usdc_token(&env)?;
-        let token_client = TokenClient::new(&env, &token);
-        token_client.transfer(&env.current_contract_address(), &recipient, &(payout as i128));
-        // Single read-modify-write for fees
-        add_accumulated_fees(&env, trade.fee)?;
-        let resolution_code: u8 = match resolution {
-            DisputeResolution::ReleaseToBuyer => 0,
-            DisputeResolution::ReleaseToSeller => 1,
-            DisputeResolution::Partial { .. } => 2,
-        };
-        analytics::on_dispute_resolved(&env, &arbitrator, resolution_code);
-        events::emit_dispute_resolved(&env, trade_id, resolution, recipient);
-        Ok(()) for the arbitrator of a resolved dispute.
+        Ok(())
+    }
+
+    /// Rate the arbitrator of a resolved dispute.
     /// Only the buyer or seller of the trade may rate, once each.
     pub fn rate_arbitrator(env: Env, trade_id: u64, rater: Address, stars: u32) -> Result<(), ContractError> {
         if !is_initialized(&env) {


### PR DESCRIPTION
closes #235 

## Summary

Resolves #235 — Smart Contract Analytics.

The `contract/src/analytics.rs` module was already fully implemented with all required metrics (trade volume, success rates, arbitrator performance, unique addresses, time windows). This PR fixes two bugs in `lib.rs` where the analytics hooks were not correctly wired to state transitions.

## Changes

**`contract/src/lib.rs`**

- **`create_trade`**: Added missing `analytics::on_trade_created(...)` call. The regular single-arbitrator trade creation path was never recording metrics — only `create_multisig_trade` had the hook.

- **`execute_dispute_resolution`**: Moved `analytics::on_dispute_resolved(...)` into the correct `Single` and `MultiSig` match arms where the arbitrator address is in scope. Removed a dangling dead-code block (leftover from a bad merge) that referenced undefined variables and had a malformed comment fused into `Ok(())`.

## Analytics Coverage (all transitions now instrumented)

| State Transition | Hook |
|---|---|
| Trade created | `on_trade_created` — volume, counts, unique addresses |
| Trade funded | `on_trade_funded` |
| Trade completed | `on_trade_completed` — fees collected |
| Dispute raised | `on_trade_disputed` |
| Dispute resolved | `on_dispute_resolved` — per-arbitrator breakdown |
| Trade cancelled | `on_trade_cancelled` |

## Query Functions (read-only, no existing behavior changed)

- `get_platform_metrics()` — raw counters
- `get_platform_stats()` — success rate, dispute rate, active trades
- `get_arbitrator_analytics(arbitrator)` — per-arbitrator performance
- `analytics_query(window)` — unified result with time window (24h/7d/30d/all-time)

## Testing

No existing tests were modified. All changes are additive hook wiring and dead-code removal.




- Add analytics::on_trade_created to create_trade (was missing, only create_multisig_trade had it)
- Move analytics::on_dispute_resolved into Single/MultiSig match arms inside execute_dispute_resolution so arbitrator address is in scope
- Remove dangling dead code block after the match that referenced undefined variables (leftover from bad merge)