### PR TITLE
Add guided onboarding wizard for new users on dashboard

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -50,3 +50,188 @@ body {
   width: 100%;
   margin: 0 auto;
 }
+
+.onboarding {
+  background: #fff;
+  border: 1px solid #e1e3e8;
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.onboarding-header {
+  margin-bottom: 1rem;
+}
+
+.onboarding-header h2 {
+  font-size: 1.2rem;
+  margin-bottom: 0.4rem;
+}
+
+.onboarding-header p {
+  color: #595f6b;
+  font-size: 0.95rem;
+}
+
+.onboarding-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: #edf1f6;
+  margin-top: 0.75rem;
+  overflow: hidden;
+}
+
+.onboarding-progress-bar {
+  height: 100%;
+  background: #1a1a2e;
+  transition: width 200ms ease;
+}
+
+.onboarding-steps {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.onboarding-step {
+  width: 100%;
+  border: 1px solid #dde2ea;
+  border-radius: 10px;
+  background: #f9fbff;
+  padding: 0.7rem;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+}
+
+.onboarding-step.active {
+  border-color: #1a1a2e;
+  background: #f2f5ff;
+}
+
+.onboarding-step-index {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  background: #1a1a2e;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.onboarding-step-content {
+  display: grid;
+}
+
+.onboarding-step-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #212633;
+}
+
+.onboarding-step-status {
+  font-size: 0.8rem;
+  margin-top: 0.2rem;
+  color: #6c7381;
+}
+
+.onboarding-step-status.completed {
+  color: #067647;
+}
+
+.onboarding-step-status.skipped {
+  color: #b54708;
+}
+
+.onboarding-card {
+  border: 1px solid #dde2ea;
+  border-radius: 10px;
+  padding: 1rem;
+  background: #fff;
+}
+
+.onboarding-card h3 {
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.onboarding-card > p {
+  color: #4d5565;
+  margin-bottom: 0.8rem;
+}
+
+.onboarding-tutorial {
+  border-top: 1px solid #edf1f6;
+  padding-top: 0.8rem;
+}
+
+.onboarding-tutorial h4 {
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.onboarding-tutorial ul {
+  margin: 0 0 0.75rem 1.2rem;
+  color: #4d5565;
+}
+
+.onboarding-tutorial li {
+  margin-bottom: 0.35rem;
+}
+
+.onboarding-link {
+  color: #1a1a2e;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.onboarding-link:hover {
+  text-decoration: underline;
+}
+
+.onboarding-controls,
+.onboarding-actions,
+.onboarding-summary-actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-top: 0.9rem;
+}
+
+.onboarding-btn {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.onboarding-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.onboarding-btn.primary {
+  background: #1a1a2e;
+  color: #fff;
+}
+
+.onboarding-btn.secondary {
+  border-color: #ccd4e0;
+  background: #fff;
+  color: #2f3746;
+}
+
+.onboarding-btn.danger {
+  border-color: #f2c6c6;
+  background: #fff5f5;
+  color: #912018;
+}

--- a/app/src/components/OnboardingFlow.tsx
+++ b/app/src/components/OnboardingFlow.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+type StepStatus = 'pending' | 'completed' | 'skipped';
+
+interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  tutorial: string[];
+  actionLabel: string;
+  actionTo: string;
+}
+
+const STORAGE_KEY = 'stellarEscrow.onboarding.v1';
+
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: 'register-profile',
+    title: 'Connect Your Wallet',
+    description: 'Connect a Stellar wallet so the app can identify your account and load your trades.',
+    tutorial: [
+      'Use the wallet button in the top navigation.',
+      'Authorize access from your wallet provider.',
+      'Confirm the connected address is the one you plan to trade with.',
+    ],
+    actionLabel: 'Go to Dashboard',
+    actionTo: '/',
+  },
+  {
+    id: 'acknowledge-fees',
+    title: 'Review Escrow Fees',
+    description: 'Understand how fees are applied before creating or funding a trade.',
+    tutorial: [
+      'Open the create trade screen and review amount inputs.',
+      'Check total trade amount and expected network/escrow costs.',
+      'Proceed only after fee expectations are clear for both parties.',
+    ],
+    actionLabel: 'Open New Trade Form',
+    actionTo: '/trades/new',
+  },
+  {
+    id: 'create-template',
+    title: 'Prepare Trade Setup',
+    description: 'Fill out seller, buyer, amount, and arbitrator details as your setup wizard step.',
+    tutorial: [
+      'Enter seller and buyer addresses carefully.',
+      'Set trade amount and select an arbitrator.',
+      'Use form validation feedback before submitting.',
+    ],
+    actionLabel: 'Continue Setup Wizard',
+    actionTo: '/trades/new',
+  },
+  {
+    id: 'create-first-trade',
+    title: 'Create Your First Trade',
+    description: 'Submit your first escrow trade and verify it appears in the trade dashboard.',
+    tutorial: [
+      'Submit the form after reviewing trade details.',
+      'Open the trade details page to verify status and events.',
+      'Share trade ID with your counterparty for funding and settlement.',
+    ],
+    actionLabel: 'Create Trade Now',
+    actionTo: '/trades/new',
+  },
+];
+
+function isStepStatus(value: unknown): value is StepStatus {
+  return value === 'pending' || value === 'completed' || value === 'skipped';
+}
+
+function defaultStatuses(): StepStatus[] {
+  return ONBOARDING_STEPS.map(() => 'pending');
+}
+
+function loadStatuses(): StepStatus[] {
+  if (typeof window === 'undefined') {
+    return defaultStatuses();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return defaultStatuses();
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length !== ONBOARDING_STEPS.length) {
+      return defaultStatuses();
+    }
+
+    if (parsed.every(isStepStatus)) {
+      return parsed;
+    }
+
+    return defaultStatuses();
+  } catch {
+    return defaultStatuses();
+  }
+}
+
+function saveStatuses(statuses: StepStatus[]): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(statuses));
+  } catch {
+    // Ignore storage failures in restricted browser modes.
+  }
+}
+
+function findNextPending(statuses: StepStatus[]): number {
+  return statuses.findIndex((status) => status === 'pending');
+}
+
+function formatStatus(status: StepStatus): string {
+  if (status === 'completed') {
+    return 'Completed';
+  }
+
+  if (status === 'skipped') {
+    return 'Skipped';
+  }
+
+  return 'Pending';
+}
+
+export default function OnboardingFlow() {
+  const [stepStatuses, setStepStatuses] = useState<StepStatus[]>(() => loadStatuses());
+  const [activeStepIndex, setActiveStepIndex] = useState<number>(0);
+
+  useEffect(() => {
+    saveStatuses(stepStatuses);
+  }, [stepStatuses]);
+
+  useEffect(() => {
+    if (stepStatuses[activeStepIndex] === 'pending') {
+      return;
+    }
+
+    const nextPending = findNextPending(stepStatuses);
+    if (nextPending >= 0) {
+      setActiveStepIndex(nextPending);
+    }
+  }, [activeStepIndex, stepStatuses]);
+
+  const pendingCount = useMemo(
+    () => stepStatuses.filter((status) => status === 'pending').length,
+    [stepStatuses]
+  );
+  const completedCount = useMemo(
+    () => stepStatuses.filter((status) => status === 'completed').length,
+    [stepStatuses]
+  );
+  const skippedCount = useMemo(
+    () => stepStatuses.filter((status) => status === 'skipped').length,
+    [stepStatuses]
+  );
+
+  const resolvedCount = ONBOARDING_STEPS.length - pendingCount;
+  const progressPercent = Math.round((resolvedCount / ONBOARDING_STEPS.length) * 100);
+  const hasPendingSteps = pendingCount > 0;
+
+  const currentStep = ONBOARDING_STEPS[activeStepIndex];
+  const currentStatus = stepStatuses[activeStepIndex];
+
+  const markCurrentStep = (status: Extract<StepStatus, 'completed' | 'skipped'>) => {
+    setStepStatuses((previous) => {
+      if (previous[activeStepIndex] !== 'pending') {
+        return previous;
+      }
+
+      const next = [...previous];
+      next[activeStepIndex] = status;
+      return next;
+    });
+  };
+
+  const skipAll = () => {
+    setStepStatuses((previous) => previous.map((status) => (status === 'pending' ? 'skipped' : status)));
+  };
+
+  const restartOnboarding = () => {
+    setStepStatuses(defaultStatuses());
+    setActiveStepIndex(0);
+  };
+
+  if (!hasPendingSteps) {
+    return (
+      <section className="onboarding" aria-labelledby="onboarding-title">
+        <div className="onboarding-header">
+          <h2 id="onboarding-title">Onboarding Complete</h2>
+          <p>
+            Completed {completedCount} of {ONBOARDING_STEPS.length} steps.
+            {skippedCount > 0 ? ` Skipped ${skippedCount} step(s).` : ''}
+          </p>
+        </div>
+        <div className="onboarding-summary-actions">
+          <button type="button" className="onboarding-btn secondary" onClick={restartOnboarding}>
+            Restart Onboarding
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="onboarding" aria-labelledby="onboarding-title">
+      <div className="onboarding-header">
+        <h2 id="onboarding-title">Getting Started</h2>
+        <p>
+          {resolvedCount} of {ONBOARDING_STEPS.length} steps complete ({progressPercent}%).
+        </p>
+        <div className="onboarding-progress" aria-label="Onboarding progress">
+          <div className="onboarding-progress-bar" style={{ width: `${progressPercent}%` }} />
+        </div>
+      </div>
+
+      <ol className="onboarding-steps" aria-label="Onboarding sequence">
+        {ONBOARDING_STEPS.map((step, index) => {
+          const status = stepStatuses[index];
+          const active = activeStepIndex === index;
+
+          return (
+            <li key={step.id}>
+              <button
+                type="button"
+                className={`onboarding-step ${active ? 'active' : ''}`}
+                onClick={() => setActiveStepIndex(index)}
+                aria-current={active ? 'step' : undefined}
+              >
+                <span className="onboarding-step-index">{index + 1}</span>
+                <span className="onboarding-step-content">
+                  <span className="onboarding-step-title">{step.title}</span>
+                  <span className={`onboarding-step-status ${status}`}>{formatStatus(status)}</span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+
+      <article className="onboarding-card" aria-live="polite">
+        <h3>{currentStep.title}</h3>
+        <p>{currentStep.description}</p>
+
+        <div className="onboarding-tutorial">
+          <h4>Tutorial</h4>
+          <ul>
+            {currentStep.tutorial.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <Link to={currentStep.actionTo} className="onboarding-link">
+            {currentStep.actionLabel}
+          </Link>
+        </div>
+
+        <div className="onboarding-controls">
+          <button
+            type="button"
+            className="onboarding-btn secondary"
+            onClick={() => setActiveStepIndex((current) => Math.max(0, current - 1))}
+            disabled={activeStepIndex === 0}
+          >
+            Previous Step
+          </button>
+          <button
+            type="button"
+            className="onboarding-btn secondary"
+            onClick={() =>
+              setActiveStepIndex((current) => Math.min(ONBOARDING_STEPS.length - 1, current + 1))
+            }
+            disabled={activeStepIndex === ONBOARDING_STEPS.length - 1}
+          >
+            Next Step
+          </button>
+        </div>
+
+        <div className="onboarding-actions">
+          <button
+            type="button"
+            className="onboarding-btn primary"
+            onClick={() => markCurrentStep('completed')}
+            disabled={currentStatus !== 'pending'}
+          >
+            Mark Complete
+          </button>
+          <button
+            type="button"
+            className="onboarding-btn secondary"
+            onClick={() => markCurrentStep('skipped')}
+            disabled={currentStatus !== 'pending'}
+          >
+            Skip Step
+          </button>
+          <button type="button" className="onboarding-btn danger" onClick={skipAll}>
+            Skip Onboarding
+          </button>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useGetTradesQuery } from '@stellar-escrow/state';
 import { TradeCard } from '@stellar-escrow/components';
+import OnboardingFlow from '../components/OnboardingFlow';
 
 export default function Dashboard() {
   const { data: trades = [], isLoading, error } = useGetTradesQuery({});
@@ -10,6 +11,7 @@ export default function Dashboard() {
 
   return (
     <div>
+      <OnboardingFlow />
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
         <h1 style={{ fontSize: '1.5rem' }}>Trades</h1>
         <Link to="/trades/new" style={{ padding: '0.5rem 1rem', background: '#1a1a2e', color: 'white', borderRadius: 6, textDecoration: 'none' }}>


### PR DESCRIPTION
Closes #269

## Summary
Adds a comprehensive onboarding flow for new users in the React app dashboard, including tutorials, guided setup, progress tracking, and skip controls.

## Root Cause
Onboarding capabilities existed in contract-side Rust modules, but there was no user-facing onboarding UI in the app entry flow.

## Fix
Added `OnboardingFlow.tsx` with:
- Four-step onboarding sequence
- Interactive tutorial guidance per step
- Wizard navigation (previous/next)
- Per-step complete/skip and full-flow skip
- Persistent progress via `localStorage`

Integrated onboarding into `Dashboard.tsx` and added onboarding-specific styles in `App.css`.

## Testing
- ✅ Changed files have no editor diagnostics
