### PR TITLE
feat: add API integration layer with retry, interceptors, and mock support

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Indexer backend URL
+VITE_INDEXER_URL=http://localhost:3000
+
+# Set to "true" to use mock API (no backend needed)
+VITE_API_MOCK=false

--- a/client/src/lib/api/client.ts
+++ b/client/src/lib/api/client.ts
@@ -1,0 +1,77 @@
+import { ApiRequestError } from './types';
+
+const RETRY_STATUSES = new Set([429, 502, 503, 504]);
+const DEFAULT_RETRIES = 3;
+const BASE_DELAY_MS = 300;
+
+export interface ClientConfig {
+  baseUrl: string;
+  retries?: number;
+  /** Called before every request — return modified init or throw to abort */
+  onRequest?: (url: string, init: RequestInit) => RequestInit | Promise<RequestInit>;
+  /** Called after every successful response */
+  onResponse?: (url: string, res: Response) => void;
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function apiFetch<T>(
+  config: ClientConfig,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const url = `${config.baseUrl}${path}`;
+  const maxAttempts = (config.retries ?? DEFAULT_RETRIES) + 1;
+
+  let attempt = 0;
+  while (attempt < maxAttempts) {
+    let reqInit: RequestInit = {
+      headers: { 'Content-Type': 'application/json', ...init.headers },
+      ...init,
+    };
+
+    if (config.onRequest) {
+      reqInit = await config.onRequest(url, reqInit);
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(url, reqInit);
+    } catch (err) {
+      if (attempt < maxAttempts - 1) {
+        await sleep(BASE_DELAY_MS * 2 ** attempt);
+        attempt++;
+        continue;
+      }
+      throw new ApiRequestError(0, 'NETWORK_ERROR', (err as Error).message);
+    }
+
+    if (res.ok) {
+      config.onResponse?.(url, res);
+      return res.json() as Promise<T>;
+    }
+
+    if (RETRY_STATUSES.has(res.status) && attempt < maxAttempts - 1) {
+      const retryAfter = res.headers.get('Retry-After');
+      const delay = retryAfter ? parseInt(retryAfter) * 1000 : BASE_DELAY_MS * 2 ** attempt;
+      await sleep(delay);
+      attempt++;
+      continue;
+    }
+
+    let code = 'API_ERROR';
+    let message = res.statusText;
+    try {
+      const body = await res.json();
+      code = body.code ?? code;
+      message = body.message ?? message;
+    } catch {
+      // non-JSON error body
+    }
+    throw new ApiRequestError(res.status, code, message);
+  }
+
+  throw new ApiRequestError(0, 'MAX_RETRIES', 'Max retries exceeded');
+}

--- a/client/src/lib/api/index.ts
+++ b/client/src/lib/api/index.ts
@@ -1,0 +1,30 @@
+import { createIndexerApi } from './indexer';
+import { mockIndexerApi } from './mock';
+import type { ClientConfig } from './client';
+
+const USE_MOCK = import.meta.env.VITE_API_MOCK === 'true';
+const BASE_URL = import.meta.env.VITE_INDEXER_URL ?? 'http://localhost:3000';
+
+const config: ClientConfig = {
+  baseUrl: BASE_URL,
+  retries: 3,
+  onRequest(url, init) {
+    // Attach auth token if present (e.g. from localStorage)
+    const token = typeof localStorage !== 'undefined' ? localStorage.getItem('auth_token') : null;
+    if (token) {
+      init.headers = { ...init.headers as Record<string, string>, Authorization: `Bearer ${token}` };
+    }
+    return init;
+  },
+  onResponse(url, res) {
+    if (import.meta.env.DEV) {
+      console.debug(`[api] ${res.status} ${url}`);
+    }
+  },
+};
+
+export const indexerApi = USE_MOCK ? mockIndexerApi : createIndexerApi(config);
+
+export { ApiRequestError } from './types';
+export type { Event, PagedResponse, TradeSearchResult } from './types';
+export type { IndexerApi } from './indexer';

--- a/client/src/lib/api/indexer.ts
+++ b/client/src/lib/api/indexer.ts
@@ -1,0 +1,47 @@
+import { apiFetch, type ClientConfig } from './client';
+import type { Event, PagedResponse, TradeSearchResult } from './types';
+
+export function createIndexerApi(config: ClientConfig) {
+  const get = <T>(path: string) => apiFetch<T>(config, path);
+  const post = <T>(path: string, body: unknown) =>
+    apiFetch<T>(config, path, { method: 'POST', body: JSON.stringify(body) });
+
+  return {
+    /** GET /events */
+    getEvents(params?: {
+      limit?: number;
+      offset?: number;
+      event_type?: string;
+      trade_id?: number;
+    }): Promise<PagedResponse<Event>> {
+      const qs = new URLSearchParams(
+        Object.entries(params ?? {})
+          .filter(([, v]) => v !== undefined)
+          .map(([k, v]) => [k, String(v)])
+      ).toString();
+      return get(`/events${qs ? `?${qs}` : ''}`);
+    },
+
+    /** GET /events/:id */
+    getEvent(id: string): Promise<Event> {
+      return get(`/events/${id}`);
+    },
+
+    /** GET /events/trade/:trade_id */
+    getTradeEvents(tradeId: number): Promise<Event[]> {
+      return get(`/events/trade/${tradeId}`);
+    },
+
+    /** GET /search/trades */
+    searchTrades(query: string): Promise<PagedResponse<TradeSearchResult>> {
+      return get(`/search/trades?q=${encodeURIComponent(query)}`);
+    },
+
+    /** POST /events/replay */
+    replayEvents(fromLedger: number, toLedger: number): Promise<{ replayed: number }> {
+      return post('/events/replay', { from_ledger: fromLedger, to_ledger: toLedger });
+    },
+  };
+}
+
+export type IndexerApi = ReturnType<typeof createIndexerApi>;

--- a/client/src/lib/api/mock.ts
+++ b/client/src/lib/api/mock.ts
@@ -1,0 +1,64 @@
+import type { Event, PagedResponse, TradeSearchResult } from './types';
+import type { IndexerApi } from './indexer';
+
+const MOCK_EVENTS: Event[] = [
+  {
+    id: 'mock-1',
+    event_type: 'trade_created',
+    contract_id: 'CDMOCK000',
+    ledger: 1000,
+    transaction_hash: 'abc123',
+    timestamp: new Date().toISOString(),
+    data: { trade_id: 1, seller: 'GSELLER', buyer: 'GBUYER', amount: 1000000 },
+    created_at: new Date().toISOString(),
+  },
+  {
+    id: 'mock-2',
+    event_type: 'trade_funded',
+    contract_id: 'CDMOCK000',
+    ledger: 1010,
+    transaction_hash: 'def456',
+    timestamp: new Date().toISOString(),
+    data: { trade_id: 1 },
+    created_at: new Date().toISOString(),
+  },
+];
+
+const delay = (ms = 200) => new Promise((r) => setTimeout(r, ms));
+
+export const mockIndexerApi: IndexerApi = {
+  async getEvents(params) {
+    await delay();
+    const limit = params?.limit ?? 20;
+    const offset = params?.offset ?? 0;
+    let items = MOCK_EVENTS;
+    if (params?.event_type) items = items.filter((e) => e.event_type === params.event_type);
+    if (params?.trade_id) items = items.filter((e) => (e.data as any).trade_id === params.trade_id);
+    return { items: items.slice(offset, offset + limit), total: items.length, limit, offset };
+  },
+
+  async getEvent(id) {
+    await delay();
+    const ev = MOCK_EVENTS.find((e) => e.id === id);
+    if (!ev) throw new Error(`Event ${id} not found`);
+    return ev;
+  },
+
+  async getTradeEvents(tradeId) {
+    await delay();
+    return MOCK_EVENTS.filter((e) => (e.data as any).trade_id === tradeId);
+  },
+
+  async searchTrades(query) {
+    await delay();
+    const results: TradeSearchResult[] = [
+      { trade_id: 1, seller: 'GSELLER', buyer: 'GBUYER', amount: 1000000, status: 'funded', created_at: new Date().toISOString() },
+    ].filter((t) => JSON.stringify(t).toLowerCase().includes(query.toLowerCase()));
+    return { items: results, total: results.length, limit: 20, offset: 0 };
+  },
+
+  async replayEvents(fromLedger, toLedger) {
+    await delay(500);
+    return { replayed: toLedger - fromLedger };
+  },
+};

--- a/client/src/lib/api/types.ts
+++ b/client/src/lib/api/types.ts
@@ -1,0 +1,43 @@
+export interface Event {
+  id: string;
+  event_type: string;
+  contract_id: string;
+  ledger: number;
+  transaction_hash: string;
+  timestamp: string;
+  data: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface PagedResponse<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface TradeSearchResult {
+  trade_id: number;
+  seller: string;
+  buyer: string;
+  amount: number;
+  status: string;
+  created_at: string;
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+  status: number;
+}
+
+export class ApiRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ApiRequestError';
+  }
+}


### PR DESCRIPTION
Closes #263

---

Adds a typed API client library under client/src/lib/api/ for communicating with the StellarEscrow indexer backend.

Changes:
- client.ts — core apiFetch wrapper with request/response interceptors and exponential backoff retry (configurable, 
respects Retry-After)
- types.ts — shared TypeScript interfaces (Event, PagedResponse, TradeSearchResult) and ApiRequestError class
- indexer.ts — typed methods for all indexer endpoints (getEvents, getTradeEvents, searchTrades, replayEvents, etc.)
- mock.ts — in-memory mock implementing the same interface with simulated latency for development without a backend
- index.ts — single import point; switches between real and mock via VITE_API_MOCK=true
- .env.example — documents VITE_INDEXER_URL and VITE_API_MOCK env vars

Usage:
ts
import { indexerApi, ApiRequestError } from '$lib/api';
const events = await indexerApi.getTradeEvents(1);