### PR TITLE
feat: integration service for third-party APIs (#318)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -109,6 +109,19 @@ export type {
   RetryConfig,
 } from './types';
 export type { ApiConfig };
+export {
+  ApiConnector,
+  IntegrationMonitor,
+  IntegrationService,
+} from './integration';
+export type {
+  IntegrationConfig,
+  IntegrationEvent,
+  IntegrationHealth,
+  IntegrationMetrics,
+  IntegrationProvider,
+  IntegrationStatus,
+} from './integration';
 export type {
   OperationPerformanceSummary,
   PerformanceAlert,

--- a/api/src/integration.test.ts
+++ b/api/src/integration.test.ts
@@ -1,0 +1,276 @@
+import { rest } from 'msw';
+import { server } from './mocks';
+import {
+  ApiConnector,
+  IntegrationConfig,
+  IntegrationMonitor,
+  IntegrationService,
+} from './integration';
+
+// ── Shared fixture ────────────────────────────────────────────────────────────
+
+const BASE_CONFIG: IntegrationConfig = {
+  id: 'test-integration',
+  name: 'Test Integration',
+  provider: 'custom',
+  baseUrl: 'https://api.example-integration.com',
+  apiKey: 'secret-token',
+};
+
+// ── ApiConnector ──────────────────────────────────────────────────────────────
+
+describe('ApiConnector', () => {
+  describe('HTTP methods', () => {
+    it('GET returns data from the third-party API', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      const data = await connector.get<{ items: unknown[] }>('/resource');
+      expect(data.items).toHaveLength(1);
+    });
+
+    it('POST creates a resource', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      const data = await connector.post<{ id: string; name: string }>('/resource', { name: 'foo' });
+      expect(data.id).toBe('r-new');
+      expect(data.name).toBe('foo');
+    });
+
+    it('PATCH updates a resource', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      const data = await connector.patch<{ id: string; name: string }>('/resource/r1', { name: 'bar' });
+      expect(data.id).toBe('r1');
+      expect(data.name).toBe('bar');
+    });
+
+    it('DELETE removes a resource without error', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      await expect(connector.delete('/resource/r1')).resolves.not.toThrow();
+    });
+  });
+
+  describe('metrics tracking', () => {
+    it('starts with zero counts', () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      const m = connector.getMetrics();
+      expect(m.totalRequests).toBe(0);
+      expect(m.successCount).toBe(0);
+      expect(m.errorCount).toBe(0);
+    });
+
+    it('increments success counts after a successful call', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      await connector.get('/resource');
+      const m = connector.getMetrics();
+      expect(m.totalRequests).toBe(1);
+      expect(m.successCount).toBe(1);
+      expect(m.errorCount).toBe(0);
+      expect(m.lastRequestAt).not.toBeNull();
+    });
+
+    it('increments error counts when the call fails', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      await expect(connector.get('/error')).rejects.toBeDefined();
+      const m = connector.getMetrics();
+      expect(m.totalRequests).toBe(1);
+      expect(m.errorCount).toBe(1);
+      expect(m.successCount).toBe(0);
+    });
+
+    it('accumulates latency across multiple calls', async () => {
+      const connector = new ApiConnector(BASE_CONFIG);
+      await connector.get('/resource');
+      await connector.get('/resource');
+      const m = connector.getMetrics();
+      expect(m.totalRequests).toBe(2);
+      expect(m.successCount).toBe(2);
+      expect(m.totalLatencyMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('auth headers', () => {
+    it('attaches Authorization header when apiKey is set', async () => {
+      let capturedAuthHeader: string | undefined;
+
+      server.use(
+        rest.get('https://api.example-integration.com/resource', (req, res, ctx) => {
+          capturedAuthHeader = req.headers.get('Authorization') ?? undefined;
+          return res(ctx.json({ items: [] }));
+        })
+      );
+
+      const connector = new ApiConnector(BASE_CONFIG);
+      await connector.get('/resource');
+
+      expect(capturedAuthHeader).toBe('Bearer secret-token');
+    });
+
+    it('merges extra static headers from config', async () => {
+      let capturedHeader: string | undefined;
+
+      server.use(
+        rest.get('https://api.example-integration.com/resource', (req, res, ctx) => {
+          capturedHeader = req.headers.get('X-Custom') ?? undefined;
+          return res(ctx.json({ items: [] }));
+        })
+      );
+
+      const connector = new ApiConnector({
+        ...BASE_CONFIG,
+        headers: { 'X-Custom': 'my-value' },
+      });
+      await connector.get('/resource');
+
+      expect(capturedHeader).toBe('my-value');
+    });
+  });
+});
+
+// ── IntegrationMonitor ────────────────────────────────────────────────────────
+
+describe('IntegrationMonitor', () => {
+  it('records a healthy status after a successful health check', async () => {
+    const monitor = new IntegrationMonitor();
+    const connector = new ApiConnector(BASE_CONFIG);
+
+    monitor.start(connector, '/health', 999_999);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const health = monitor.getHealth(BASE_CONFIG.id);
+    expect(health).toBeDefined();
+    expect(health?.status).toBe('active');
+    expect(health?.latencyMs).toBeGreaterThanOrEqual(0);
+    monitor.stopAll();
+  });
+
+  it('records an error status when the health endpoint fails', async () => {
+    server.use(
+      rest.get('https://api.example-integration.com/health', (_req, res, ctx) =>
+        res(ctx.status(503), ctx.json({ message: 'Service unavailable' }))
+      )
+    );
+
+    const monitor = new IntegrationMonitor();
+    const connector = new ApiConnector(BASE_CONFIG);
+    monitor.start(connector, '/health', 999_999);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const health = monitor.getHealth(BASE_CONFIG.id);
+    expect(health?.status).toBe('error');
+    expect(health?.error).toBeDefined();
+    monitor.stopAll();
+  });
+
+  it('getAllHealth returns records for all monitored integrations', async () => {
+    const monitor = new IntegrationMonitor();
+    const c1 = new ApiConnector({ ...BASE_CONFIG, id: 'int-a' });
+    const c2 = new ApiConnector({ ...BASE_CONFIG, id: 'int-b' });
+    monitor.start(c1, '/health', 999_999);
+    monitor.start(c2, '/health', 999_999);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(monitor.getAllHealth()).toHaveLength(2);
+    monitor.stopAll();
+  });
+});
+
+// ── IntegrationService ────────────────────────────────────────────────────────
+
+describe('IntegrationService', () => {
+  let service: IntegrationService;
+
+  beforeEach(() => {
+    service = new IntegrationService();
+  });
+
+  afterEach(() => {
+    service.clear();
+  });
+
+  describe('register', () => {
+    it('registers a connector and returns it', () => {
+      const connector = service.register(BASE_CONFIG);
+      expect(connector).toBeInstanceOf(ApiConnector);
+    });
+
+    it('throws when registering a duplicate id', () => {
+      service.register(BASE_CONFIG);
+      expect(() => service.register(BASE_CONFIG)).toThrow(/already registered/);
+    });
+
+    it('throws when the integration is disabled', () => {
+      expect(() =>
+        service.register({ ...BASE_CONFIG, id: 'disabled', enabled: false })
+      ).toThrow(/disabled/);
+    });
+  });
+
+  describe('connector', () => {
+    it('returns the registered connector', () => {
+      service.register(BASE_CONFIG);
+      expect(service.connector(BASE_CONFIG.id)).toBeInstanceOf(ApiConnector);
+    });
+
+    it('throws when the id is not registered', () => {
+      expect(() => service.connector('unknown')).toThrow(/not registered/);
+    });
+  });
+
+  describe('has', () => {
+    it('returns true for a registered integration', () => {
+      service.register(BASE_CONFIG);
+      expect(service.has(BASE_CONFIG.id)).toBe(true);
+    });
+
+    it('returns false for an unregistered id', () => {
+      expect(service.has('not-here')).toBe(false);
+    });
+  });
+
+  describe('deregister', () => {
+    it('removes the integration', () => {
+      service.register(BASE_CONFIG);
+      service.deregister(BASE_CONFIG.id);
+      expect(service.has(BASE_CONFIG.id)).toBe(false);
+    });
+
+    it('allows re-registration after deregister', () => {
+      service.register(BASE_CONFIG);
+      service.deregister(BASE_CONFIG.id);
+      expect(() => service.register(BASE_CONFIG)).not.toThrow();
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('returns empty array when no integrations are registered', () => {
+      expect(service.getMetrics()).toEqual([]);
+    });
+
+    it('returns metrics for all registered integrations', () => {
+      service.register(BASE_CONFIG);
+      service.register({ ...BASE_CONFIG, id: 'second' });
+      const metrics = service.getMetrics();
+      expect(metrics).toHaveLength(2);
+      expect(metrics.map((m) => m.integrationId)).toContain(BASE_CONFIG.id);
+    });
+  });
+
+  describe('getEventLog', () => {
+    it('logs a REGISTER event when an integration is registered', () => {
+      service.register(BASE_CONFIG);
+      const log = service.getEventLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].method).toBe('REGISTER');
+      expect(log[0].integrationId).toBe(BASE_CONFIG.id);
+    });
+  });
+
+  describe('end-to-end', () => {
+    it('calls the third-party API through the service', async () => {
+      service.register(BASE_CONFIG);
+      const connector = service.connector(BASE_CONFIG.id);
+      const data = await connector.get<{ items: unknown[] }>('/resource');
+      expect(data.items).toHaveLength(1);
+
+      const metrics = service.getMetrics().find((m) => m.integrationId === BASE_CONFIG.id);
+      expect(metrics?.successCount).toBe(1);
+    });
+  });
+});

--- a/api/src/integration.ts
+++ b/api/src/integration.ts
@@ -1,0 +1,306 @@
+import { ApiClient } from './client';
+import { ApiClientConfig } from './types';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type IntegrationProvider =
+  | 'github'
+  | 'slack'
+  | 'stripe'
+  | 'sendgrid'
+  | 'twilio'
+  | 'pagerduty'
+  | 'custom';
+
+export type IntegrationStatus = 'active' | 'inactive' | 'error';
+
+export interface IntegrationConfig {
+  /** Unique integration identifier */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  provider: IntegrationProvider;
+  /** Base URL of the third-party API */
+  baseUrl: string;
+  /** Auth token / API key (Bearer header) */
+  apiKey?: string;
+  /** Additional static headers to send with every request */
+  headers?: Record<string, string>;
+  /** Request timeout override in ms (default: 15 000) */
+  timeoutMs?: number;
+  /** Whether this integration is currently active */
+  enabled?: boolean;
+}
+
+export interface IntegrationHealth {
+  integrationId: string;
+  status: IntegrationStatus;
+  latencyMs: number | null;
+  checkedAt: string;
+  error?: string;
+}
+
+export interface IntegrationMetrics {
+  integrationId: string;
+  totalRequests: number;
+  successCount: number;
+  errorCount: number;
+  totalLatencyMs: number;
+  lastRequestAt: string | null;
+}
+
+export interface IntegrationEvent {
+  integrationId: string;
+  endpoint: string;
+  method: string;
+  payload?: unknown;
+  timestamp: string;
+}
+
+// ── Connector ─────────────────────────────────────────────────────────────────
+
+/**
+ * ApiConnector wraps an ApiClient for a specific third-party service.
+ * It records per-call metrics and exposes typed helpers.
+ */
+export class ApiConnector {
+  private client: ApiClient;
+  private metrics: IntegrationMetrics;
+
+  constructor(private config: IntegrationConfig) {
+    const headers: Record<string, string> = { ...config.headers };
+    if (config.apiKey) {
+      headers['Authorization'] = `Bearer ${config.apiKey}`;
+    }
+
+    const clientConfig: ApiClientConfig = {
+      baseURL: config.baseUrl,
+      timeout: config.timeoutMs ?? 15_000,
+      retryConfig: { maxRetries: 2, delayMs: 500, backoffMultiplier: 2 },
+    };
+
+    this.client = new ApiClient(clientConfig);
+
+    // Attach static headers via request interceptor
+    if (Object.keys(headers).length > 0) {
+      this.client.addRequestInterceptor((reqConfig) => {
+        reqConfig.headers = { ...(reqConfig.headers ?? {}), ...headers };
+        return reqConfig;
+      });
+    }
+
+    this.metrics = {
+      integrationId: config.id,
+      totalRequests: 0,
+      successCount: 0,
+      errorCount: 0,
+      totalLatencyMs: 0,
+      lastRequestAt: null,
+    };
+  }
+
+  /** Send a GET request to the third-party API. */
+  async get<T = unknown>(path: string): Promise<T> {
+    return this.track('GET', path, () => this.client.get<T>(path));
+  }
+
+  /** Send a POST request to the third-party API. */
+  async post<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.track('POST', path, () => this.client.post<T>(path, body));
+  }
+
+  /** Send a PATCH request to the third-party API. */
+  async patch<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.track('PATCH', path, () => this.client.patch<T>(path, body));
+  }
+
+  /** Send a DELETE request to the third-party API. */
+  async delete<T = unknown>(path: string): Promise<T> {
+    return this.track('DELETE', path, () => this.client.delete<T>(path));
+  }
+
+  /** Snapshot of call metrics for this connector. */
+  getMetrics(): Readonly<IntegrationMetrics> {
+    return { ...this.metrics };
+  }
+
+  /** Configuration used to build this connector. */
+  getConfig(): Readonly<IntegrationConfig> {
+    return { ...this.config };
+  }
+
+  private async track<T>(method: string, path: string, fn: () => Promise<T>): Promise<T> {
+    const start = Date.now();
+    this.metrics.totalRequests++;
+    this.metrics.lastRequestAt = new Date().toISOString();
+    try {
+      const result = await fn();
+      this.metrics.successCount++;
+      this.metrics.totalLatencyMs += Date.now() - start;
+      return result;
+    } catch (err) {
+      this.metrics.errorCount++;
+      this.metrics.totalLatencyMs += Date.now() - start;
+      throw err;
+    }
+  }
+}
+
+// ── Integration monitor ───────────────────────────────────────────────────────
+
+/**
+ * IntegrationMonitor periodically pings a health-check endpoint and records
+ * the result.  Call `start()` / `stop()` to manage the polling lifecycle.
+ */
+export class IntegrationMonitor {
+  private healthRecords: Map<string, IntegrationHealth> = new Map();
+  private timers: Map<string, ReturnType<typeof setInterval>> = new Map();
+
+  /**
+   * Start health-check polling for a connector.
+   * @param connector      The connector to check.
+   * @param healthPath     Endpoint to ping (default `/health`).
+   * @param intervalMs     How often to poll (default 60 000 ms).
+   */
+  start(
+    connector: ApiConnector,
+    healthPath = '/health',
+    intervalMs = 60_000,
+  ): void {
+    const id = connector.getConfig().id;
+    if (this.timers.has(id)) return; // already polling
+
+    const check = async () => {
+      const start = Date.now();
+      try {
+        await connector.get(healthPath);
+        this.healthRecords.set(id, {
+          integrationId: id,
+          status: 'active',
+          latencyMs: Date.now() - start,
+          checkedAt: new Date().toISOString(),
+        });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.healthRecords.set(id, {
+          integrationId: id,
+          status: 'error',
+          latencyMs: Date.now() - start,
+          checkedAt: new Date().toISOString(),
+          error: message,
+        });
+      }
+    };
+
+    void check();
+    this.timers.set(id, setInterval(check, intervalMs));
+  }
+
+  /** Stop polling for a specific connector. */
+  stop(connectorId: string): void {
+    const timer = this.timers.get(connectorId);
+    if (timer !== undefined) {
+      clearInterval(timer);
+      this.timers.delete(connectorId);
+    }
+  }
+
+  /** Stop all polling timers. */
+  stopAll(): void {
+    for (const id of this.timers.keys()) {
+      this.stop(id);
+    }
+  }
+
+  /** Get the latest health record for an integration. */
+  getHealth(connectorId: string): IntegrationHealth | undefined {
+    return this.healthRecords.get(connectorId);
+  }
+
+  /** Get all recorded health statuses. */
+  getAllHealth(): IntegrationHealth[] {
+    return Array.from(this.healthRecords.values());
+  }
+}
+
+// ── Integration service ───────────────────────────────────────────────────────
+
+/**
+ * IntegrationService is the central registry for third-party API connectors.
+ *
+ * Usage:
+ * ```ts
+ * const svc = new IntegrationService();
+ * svc.register({ id: 'gh', name: 'GitHub', provider: 'github', baseUrl: 'https://api.github.com', apiKey: token });
+ * const repos = await svc.connector('gh').get<Repo[]>('/user/repos');
+ * ```
+ */
+export class IntegrationService {
+  private connectors: Map<string, ApiConnector> = new Map();
+  private eventLog: IntegrationEvent[] = [];
+  readonly monitor = new IntegrationMonitor();
+
+  /**
+   * Register a new integration.
+   * @throws if an integration with the same `id` already exists.
+   */
+  register(config: IntegrationConfig): ApiConnector {
+    if (this.connectors.has(config.id)) {
+      throw new Error(`Integration "${config.id}" is already registered`);
+    }
+
+    const enabled = config.enabled !== false;
+    if (!enabled) {
+      throw new Error(`Integration "${config.id}" is disabled`);
+    }
+
+    const connector = new ApiConnector(config);
+    this.connectors.set(config.id, connector);
+    this.log({ integrationId: config.id, endpoint: '(registered)', method: 'REGISTER', timestamp: new Date().toISOString() });
+    return connector;
+  }
+
+  /**
+   * Returns the connector for an existing integration.
+   * @throws if the integration is not registered.
+   */
+  connector(id: string): ApiConnector {
+    const c = this.connectors.get(id);
+    if (!c) throw new Error(`Integration "${id}" is not registered`);
+    return c;
+  }
+
+  /** Returns true if an integration with the given id is registered. */
+  has(id: string): boolean {
+    return this.connectors.has(id);
+  }
+
+  /** Deregister an integration and stop its health monitoring. */
+  deregister(id: string): void {
+    this.monitor.stop(id);
+    this.connectors.delete(id);
+  }
+
+  /** Deregister all integrations. */
+  clear(): void {
+    this.monitor.stopAll();
+    this.connectors.clear();
+  }
+
+  /** Aggregate metrics for all registered integrations. */
+  getMetrics(): IntegrationMetrics[] {
+    return Array.from(this.connectors.values()).map((c) => c.getMetrics());
+  }
+
+  /** Recent integration event log (up to last 500 entries). */
+  getEventLog(): IntegrationEvent[] {
+    return [...this.eventLog];
+  }
+
+  private log(event: IntegrationEvent): void {
+    this.eventLog.push(event);
+    if (this.eventLog.length > 500) {
+      this.eventLog.shift();
+    }
+  }
+}

--- a/api/src/mocks.ts
+++ b/api/src/mocks.ts
@@ -19,6 +19,8 @@ const initialEvents: Event[] = [
   {
     id: '1',
     type: 'trade_created',
+    category: 'trade',
+    schemaVersion: 1,
     tradeId: '1',
     timestamp: '2024-03-25T10:30:00Z',
     data: {},
@@ -27,6 +29,7 @@ const initialEvents: Event[] = [
 import { tradeHandlers } from './mocks/handlers/trades';
 import { eventHandlers } from './mocks/handlers/events';
 import { blockchainHandlers } from './mocks/handlers/blockchain';
+import { integrationHandlers } from './mocks/handlers/integration';
 
 let mockTrades: Trade[] = [];
 let mockEvents: Event[] = [];
@@ -123,4 +126,7 @@ export const handlers = [
   ...tradeHandlers,
   ...eventHandlers,
   ...blockchainHandlers,
+  ...integrationHandlers,
 ];
+
+export const server = setupServer(...handlers);

--- a/api/src/mocks/handlers/integration.ts
+++ b/api/src/mocks/handlers/integration.ts
@@ -1,0 +1,32 @@
+import { rest } from 'msw';
+
+const THIRD_PARTY_BASE = 'https://api.example-integration.com';
+
+export const integrationHandlers = [
+  // Health-check endpoint
+  rest.get(`${THIRD_PARTY_BASE}/health`, (_req, res, ctx) =>
+    res(ctx.json({ status: 'ok' }))
+  ),
+
+  // Generic resource endpoint — echo the request back
+  rest.get(`${THIRD_PARTY_BASE}/resource`, (_req, res, ctx) =>
+    res(ctx.json({ items: [{ id: 'r1', value: 'test' }] }))
+  ),
+
+  rest.post(`${THIRD_PARTY_BASE}/resource`, (req, res, ctx) =>
+    res(ctx.status(201), ctx.json({ id: 'r-new', ...(req.body as object) }))
+  ),
+
+  rest.patch(`${THIRD_PARTY_BASE}/resource/:id`, (req, res, ctx) =>
+    res(ctx.json({ id: req.params.id, ...(req.body as object) }))
+  ),
+
+  rest.delete(`${THIRD_PARTY_BASE}/resource/:id`, (_req, res, ctx) =>
+    res(ctx.status(204))
+  ),
+
+  // Simulate a 500 error for error-handling tests
+  rest.get(`${THIRD_PARTY_BASE}/error`, (_req, res, ctx) =>
+    res(ctx.status(500), ctx.json({ message: 'Internal server error' }))
+  ),
+];

--- a/api/src/mocks/handlers/trades.ts
+++ b/api/src/mocks/handlers/trades.ts
@@ -1,4 +1,5 @@
 import { rest } from 'msw';
+import { Trade } from '../../models';
 import { mockTrades } from '../data';
 
 export const tradeHandlers = [
@@ -13,7 +14,8 @@ export const tradeHandlers = [
   }),
 
   rest.post('/api/trades', (req, res, ctx) => {
-    const newTrade = { id: String(mockTrades.length + 1), ...req.body };
+    const body = req.body as Partial<Trade> | null;
+    const newTrade: Trade = { id: String(mockTrades.length + 1), ...(body ?? {}) } as Trade;
     mockTrades.push(newTrade);
     return res(ctx.status(201), ctx.json(newTrade));
   }),

--- a/api/src/test/performanceTestUtils.ts
+++ b/api/src/test/performanceTestUtils.ts
@@ -20,6 +20,8 @@ export function createEventFixture(overrides: Partial<Event> = {}): Event {
   return {
     id: '1',
     type: 'trade_created',
+    category: 'trade',
+    schemaVersion: 1,
     tradeId: '1',
     timestamp: '2024-03-25T10:30:00Z',
     data: {},


### PR DESCRIPTION
Closes #318

- Add IntegrationService as central registry for third-party API connectors
- Add ApiConnector wrapping ApiClient with per-call metrics tracking (totalRequests, successCount, errorCount, totalLatencyMs, lastRequestAt)
- Add IntegrationMonitor for periodic health-check polling with status recording (active/error) per integration
- Export all types and classes from api/src/index.ts
- Add MSW mock handlers for third-party integration endpoints
- Add 26 integration tests covering HTTP methods, metrics, auth headers, health monitoring, and IntegrationService lifecycle (register, connector, deregister, event log, end-to-end)
- Fix pre-existing TypeScript errors: missing Event fields in mocks, missing Trade import, missing server export in mocks.ts