### PR TITLE
feat(monitoring): implement APM performance monitoring system 

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -94,14 +94,46 @@ Metrics are collected at three layers:
 | Layer | Mechanism | Endpoint |
 |-------|-----------|---------|
 | Infrastructure | `HealthMonitor` (Rust) | `GET /health/metrics` |
+| APM (request-level) | `PerformanceService` (Rust) | `GET /performance/dashboard` |
+| APM alerts | `PerformanceService` alert rules | `GET /performance/alerts` |
+| APM history | Hourly rollup (materialized view) | `GET /performance/history` |
+| Prometheus scrape | `MonitoringService` + APM metrics | `GET /metrics` |
 | Web Vitals | `observeWebVitals()` (JS) | beacons → `POST /api/metrics` |
 | CDN | `observeCdnPerformance()` (JS) | beacons → `POST /api/metrics` |
 | SSL | `monitorTlsConnection()` (JS) | beacons → `POST /api/metrics` |
+
+### APM Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /performance/dashboard` | Full APM snapshot: per-route stats, overall P95/P99, active alerts |
+| `GET /performance/alerts` | Active performance alerts only |
+| `GET /performance/history` | Hourly rollup from `perf_metrics_hourly` (last 24h) |
+| `POST /performance/record` | Ingest a sample `{ route, method, status, duration_ms }` |
+| `GET /metrics` | Prometheus text format (monitoring + APM metrics) |
+
+### Grafana Dashboards
+
+| Dashboard | UID | Description |
+|-----------|-----|-------------|
+| StellarEscrow Platform | `stellar-escrow-main` | Business metrics (trades, compliance, fraud) |
+| APM — Performance | `stellar-escrow-apm` | Latency (avg/P95/P99), error rate, throughput, DB query time |
+| Code Quality | `code-quality` | CI lint/security metrics |
+
+### Alert Rules
+
+| File | Group | Alerts |
+|------|-------|--------|
+| `alert_rules.yml` | `stellar_escrow_platform` | Error rate, disputes, fraud |
+| `alert_rules_security.yml` | `stellar_escrow_compliance` | AML, compliance blocks |
+| `alert_rules_performance.yml` | `stellar_escrow_performance` | Latency (avg/P95), error rate, DB queries, throughput |
 
 ### Key Metrics to Watch
 
 - **TTFB** < 200ms (good), < 800ms (acceptable)
 - **LCP** < 2.5s
+- **Avg response time** < 500ms (warning at 500ms, critical at 2000ms)
+- **P95 response time** < 1000ms (warning at 1000ms, critical at 5000ms)
 - **DB query mean** < 10ms for hot paths (`get_events`, `search_trades`)
 - **Redis hit rate** > 80% under normal load
 - **Indexer memory** < 256MB under normal load

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,9 @@ services:
       - "127.0.0.1:9090:9090"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+      - ./monitoring/alert_rules_security.yml:/etc/prometheus/alert_rules_security.yml:ro
+      - ./monitoring/alert_rules_performance.yml:/etc/prometheus/alert_rules_performance.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/indexer/migrations/20260329000000_apm_views.sql
+++ b/indexer/migrations/20260329000000_apm_views.sql
@@ -1,0 +1,30 @@
+-- APM query helpers: materialized view + index for fast dashboard queries
+
+-- Hourly rollup view for performance metrics
+CREATE MATERIALIZED VIEW IF NOT EXISTS perf_metrics_hourly AS
+SELECT
+    date_trunc('hour', recorded_at)          AS hour,
+    route,
+    method,
+    COUNT(*)                                  AS requests,
+    SUM(CASE WHEN is_error THEN 1 ELSE 0 END) AS errors,
+    AVG(duration_ms)                          AS avg_ms,
+    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_ms,
+    PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY duration_ms) AS p99_ms
+FROM performance_metrics
+GROUP BY 1, 2, 3
+WITH NO DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_perf_hourly_pk
+    ON perf_metrics_hourly (hour DESC, route, method);
+
+-- Refresh function (called by background job or cron)
+CREATE OR REPLACE FUNCTION refresh_perf_hourly()
+RETURNS void LANGUAGE sql AS $$
+    REFRESH MATERIALIZED VIEW CONCURRENTLY perf_metrics_hourly;
+$$;
+
+-- Index to speed up alert history queries
+CREATE INDEX IF NOT EXISTS idx_perf_alerts_unresolved
+    ON performance_alerts (triggered_at DESC)
+    WHERE resolved_at IS NULL;

--- a/indexer/src/database.rs
+++ b/indexer/src/database.rs
@@ -1155,7 +1155,43 @@ impl Database {
         .execute(&self.pool)
         .await?;
         Ok(())
-    pub async fn get_integration_deliveries(
+    }
+
+    /// Query the hourly APM rollup materialized view for the last `hours` hours.
+    pub async fn get_perf_hourly_rollup(
+        &self,
+        hours: i64,
+    ) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        let rows = sqlx::query(
+            r#"
+            SELECT hour, route, method, requests, errors, avg_ms, p95_ms, p99_ms
+            FROM perf_metrics_hourly
+            WHERE hour >= NOW() - ($1 || ' hours')::INTERVAL
+            ORDER BY hour DESC
+            LIMIT 500
+            "#,
+        )
+        .bind(hours)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                use sqlx::Row;
+                serde_json::json!({
+                    "hour": r.get::<chrono::DateTime<chrono::Utc>, _>("hour"),
+                    "route": r.get::<String, _>("route"),
+                    "method": r.get::<String, _>("method"),
+                    "requests": r.get::<i64, _>("requests"),
+                    "errors": r.get::<i64, _>("errors"),
+                    "avg_ms": r.get::<f64, _>("avg_ms"),
+                    "p95_ms": r.get::<f64, _>("p95_ms"),
+                    "p99_ms": r.get::<f64, _>("p99_ms"),
+                })
+            })
+            .collect())
+    }
         &self,
         connector_id: Option<&str>,
         limit: i64,

--- a/indexer/src/handlers.rs
+++ b/indexer/src/handlers.rs
@@ -569,6 +569,34 @@ pub async fn get_performance_alerts(
     }))
 }
 
+#[derive(serde::Deserialize)]
+pub struct PerfRecordBody {
+    pub route: String,
+    pub method: String,
+    pub status: u16,
+    pub duration_ms: u64,
+}
+
+/// POST /performance/record — ingest a single APM sample (used by middleware / external agents).
+pub async fn record_performance_sample(
+    State(state): State<AppState>,
+    Json(body): Json<PerfRecordBody>,
+) -> StatusCode {
+    state
+        .performance_service
+        .record(&body.route, &body.method, body.status, body.duration_ms)
+        .await;
+    StatusCode::NO_CONTENT
+}
+
+/// GET /performance/history — hourly rollup from the materialized view.
+pub async fn get_performance_history(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let rows = state.database.get_perf_hourly_rollup(24).await?;
+    Ok(Json(serde_json::json!({ "hours": rows })))
+}
+
 // =============================================================================
 // Analytics Handlers
 // =============================================================================
@@ -854,11 +882,42 @@ pub async fn get_monitoring_alerts(
     Ok(Json(serde_json::to_value(&alerts).unwrap_or_default()))
 }
 
-/// GET /monitoring/metrics — Prometheus-format metrics.
+/// GET /monitoring/metrics — Prometheus-format metrics (monitoring + APM).
 pub async fn get_prometheus_metrics(
     State(state): State<AppState>,
 ) -> axum::response::Response<String> {
-    let body = state.monitoring_service.prometheus_metrics();
+    let mut body = state.monitoring_service.prometheus_metrics();
+
+    // Append APM metrics from the performance service
+    let dash = state.performance_service.dashboard().await;
+    let apm = format!(
+        "\n# HELP stellar_escrow_api_avg_response_ms Average API response time in ms\n\
+         # TYPE stellar_escrow_api_avg_response_ms gauge\n\
+         stellar_escrow_api_avg_response_ms {avg}\n\
+         # HELP stellar_escrow_api_p95_response_ms P95 API response time in ms\n\
+         # TYPE stellar_escrow_api_p95_response_ms gauge\n\
+         stellar_escrow_api_p95_response_ms {p95}\n\
+         # HELP stellar_escrow_api_p99_response_ms P99 API response time in ms\n\
+         # TYPE stellar_escrow_api_p99_response_ms gauge\n\
+         stellar_escrow_api_p99_response_ms {p99}\n\
+         # HELP stellar_escrow_api_requests_total Total API requests recorded\n\
+         # TYPE stellar_escrow_api_requests_total counter\n\
+         stellar_escrow_api_requests_total {total}\n\
+         # HELP stellar_escrow_api_requests_per_minute API requests per minute\n\
+         # TYPE stellar_escrow_api_requests_per_minute gauge\n\
+         stellar_escrow_api_requests_per_minute {rpm}\n\
+         # HELP stellar_escrow_active_perf_alerts Number of active performance alerts\n\
+         # TYPE stellar_escrow_active_perf_alerts gauge\n\
+         stellar_escrow_active_perf_alerts {alerts}\n",
+        avg = dash.overall.avg_ms,
+        p95 = dash.overall.p95_ms,
+        p99 = dash.overall.p99_ms,
+        total = dash.overall.total_requests,
+        rpm = dash.overall.requests_per_minute,
+        alerts = dash.active_alerts.len(),
+    );
+    body.push_str(&apm);
+
     axum::response::Response::builder()
         .status(200)
         .header("Content-Type", "text/plain; version=0.0.4")

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -292,6 +292,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Performance monitoring
         .route("/performance/dashboard", get(get_performance_dashboard))
         .route("/performance/alerts", get(get_performance_alerts))
+        .route("/performance/record", post(record_performance_sample))
+        .route("/performance/history", get(get_performance_history))
         // Compliance
         .route("/compliance/check", post(run_compliance_check))
         .route("/compliance/status/:address", get(get_compliance_status))

--- a/indexer/src/monitoring_service/metrics.rs
+++ b/indexer/src/monitoring_service/metrics.rs
@@ -98,3 +98,11 @@ pub const METRIC_API_REQUEST_DURATION_MS: &str = "stellar_escrow_api_request_dur
 pub const METRIC_WEBSOCKET_CONNECTIONS: &str = "stellar_escrow_websocket_connections";
 pub const METRIC_FRAUD_ALERTS: &str = "stellar_escrow_fraud_alerts_total";
 pub const METRIC_ERROR_RATE: &str = "stellar_escrow_error_rate";
+
+// APM-specific metrics exposed to Prometheus
+pub const METRIC_API_AVG_RESPONSE_MS: &str = "stellar_escrow_api_avg_response_ms";
+pub const METRIC_API_P95_RESPONSE_MS: &str = "stellar_escrow_api_p95_response_ms";
+pub const METRIC_API_P99_RESPONSE_MS: &str = "stellar_escrow_api_p99_response_ms";
+pub const METRIC_API_REQUESTS_TOTAL: &str = "stellar_escrow_api_requests_total";
+pub const METRIC_API_REQUESTS_PER_MINUTE: &str = "stellar_escrow_api_requests_per_minute";
+pub const METRIC_ACTIVE_PERF_ALERTS: &str = "stellar_escrow_active_perf_alerts";

--- a/monitoring/alert_rules_performance.yml
+++ b/monitoring/alert_rules_performance.yml
@@ -1,0 +1,74 @@
+groups:
+  - name: stellar_escrow_performance
+    rules:
+      - alert: HighAvgLatency
+        expr: stellar_escrow_api_avg_response_ms > 500
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High average API latency"
+          description: "Average response time is {{ $value }}ms (threshold: 500ms)."
+
+      - alert: CriticalAvgLatency
+        expr: stellar_escrow_api_avg_response_ms > 2000
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical average API latency"
+          description: "Average response time is {{ $value }}ms (threshold: 2000ms)."
+
+      - alert: HighP95Latency
+        expr: stellar_escrow_api_p95_response_ms > 1000
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High P95 API latency"
+          description: "P95 response time is {{ $value }}ms (threshold: 1000ms)."
+
+      - alert: CriticalP95Latency
+        expr: stellar_escrow_api_p95_response_ms > 5000
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical P95 API latency"
+          description: "P95 response time is {{ $value }}ms (threshold: 5000ms)."
+
+      - alert: HighAPIErrorRate
+        expr: stellar_escrow_error_rate > 5
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API error rate"
+          description: "Error rate is {{ $value }}% (threshold: 5%)."
+
+      - alert: CriticalAPIErrorRate
+        expr: stellar_escrow_error_rate > 20
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical API error rate"
+          description: "Error rate is {{ $value }}% (threshold: 20%)."
+
+      - alert: SlowDBQueries
+        expr: stellar_escrow_db_query_duration_ms > 500
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow database queries detected"
+          description: "DB query duration is {{ $value }}ms (threshold: 500ms)."
+
+      - alert: LowThroughput
+        expr: stellar_escrow_api_requests_per_minute < 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Very low API throughput"
+          description: "Requests per minute dropped to {{ $value }}."

--- a/monitoring/grafana/provisioning/dashboards/apm.json
+++ b/monitoring/grafana/provisioning/dashboards/apm.json
@@ -1,0 +1,177 @@
+{
+  "title": "StellarEscrow APM — Performance",
+  "uid": "stellar-escrow-apm",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Avg Response Time (ms)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "stellar_escrow_api_avg_response_ms", "legendFormat": "Avg ms" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "P95 Response Time (ms)",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "stellar_escrow_api_p95_response_ms", "legendFormat": "P95 ms" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 1000 },
+              { "color": "red", "value": 5000 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "P99 Response Time (ms)",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "stellar_escrow_api_p99_response_ms", "legendFormat": "P99 ms" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 2000 },
+              { "color": "red", "value": 10000 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Error Rate (%)",
+      "type": "gauge",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "stellar_escrow_error_rate", "legendFormat": "Error %" }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Requests / Minute",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "stellar_escrow_api_requests_per_minute", "legendFormat": "req/min" }],
+      "fieldConfig": { "defaults": { "unit": "reqpm" } }
+    },
+    {
+      "id": 6,
+      "title": "Active Performance Alerts",
+      "type": "stat",
+      "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "stellar_escrow_active_perf_alerts", "legendFormat": "Alerts" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Response Time Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 16, "h": 8 },
+      "targets": [
+        { "expr": "stellar_escrow_api_avg_response_ms", "legendFormat": "Avg" },
+        { "expr": "stellar_escrow_api_p95_response_ms", "legendFormat": "P95" },
+        { "expr": "stellar_escrow_api_p99_response_ms", "legendFormat": "P99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 8,
+      "title": "DB Query Duration (ms)",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 4, "w": 8, "h": 8 },
+      "targets": [
+        { "expr": "stellar_escrow_db_query_duration_ms", "legendFormat": "DB Query ms" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Total Requests",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 8 },
+      "targets": [
+        { "expr": "stellar_escrow_api_requests_total", "legendFormat": "Total Requests" }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Error Rate Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 8 },
+      "targets": [
+        { "expr": "stellar_escrow_error_rate", "legendFormat": "Error Rate %" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -10,6 +10,7 @@ alerting:
 rule_files:
   - "alert_rules.yml"
   - "alert_rules_security.yml"
+  - "alert_rules_performance.yml"
 
 scrape_configs:
   - job_name: "stellar-escrow-indexer"


### PR DESCRIPTION
closes #319 
## Summary
Implements comprehensive performance monitoring and alerting as required by Issue #81. Builds on the existing PerformanceService and MonitoringService foundations to add missing APM dashboards, alert rules, Prometheus metrics export, and DB-backed history queries.

## Changes

### New: APM Grafana Dashboard (monitoring/grafana/provisioning/dashboards/apm.json)
- Dedicated 'StellarEscrow APM — Performance' dashboard (uid: stellar-escrow-apm)
- Panels: avg/P95/P99 response time stats, error rate gauge, requests/min, active alert count, response time timeseries, DB query duration, error rate over time, total requests over time
- All panels wired to Prometheus metrics with colour-coded thresholds

### New: Performance Alert Rules (monitoring/alert_rules_performance.yml)
- Group: stellar_escrow_performance
- HighAvgLatency (warning >500ms for 2m)
- CriticalAvgLatency (critical >2000ms for 1m)
- HighP95Latency (warning >1000ms for 2m)
- CriticalP95Latency (critical >5000ms for 1m)
- HighAPIErrorRate (warning >5% for 2m)
- CriticalAPIErrorRate (critical >20% for 1m)
- SlowDBQueries (warning >500ms for 3m)
- LowThroughput (warning <1 req/min for 5m)

### New: APM DB Migration (indexer/migrations/20260329000000_apm_views.sql)
- Materialized view perf_metrics_hourly: hourly rollup with avg/P95/P99 per route
- Unique index for CONCURRENTLY refresh support
- refresh_perf_hourly() SQL function for scheduled refresh
- Partial index on performance_alerts for unresolved alert queries

### Updated: Prometheus metrics endpoint (indexer/src/handlers.rs)
- GET /metrics now appends APM metrics from PerformanceService: stellar_escrow_api_avg_response_ms, _p95_, _p99_, _requests_total, _requests_per_minute, stellar_escrow_active_perf_alerts
- New POST /performance/record — ingest APM sample from middleware/agents
- New GET /performance/history — hourly rollup (last 24h) from materialized view

### Updated: Database (indexer/src/database.rs)
- Added get_perf_hourly_rollup(hours) querying perf_metrics_hourly view

### Updated: Metric name constants (indexer/src/monitoring_service/metrics.rs)
- Added APM constants: METRIC_API_AVG_RESPONSE_MS, _P95_, _P99_, _REQUESTS_TOTAL, _REQUESTS_PER_MINUTE, METRIC_ACTIVE_PERF_ALERTS

### Updated: Prometheus config (monitoring/prometheus.yml)
- Added alert_rules_performance.yml to rule_files list

### Updated: docker-compose.yml
- Explicitly mount all three alert rule files into Prometheus container

### Updated: PERFORMANCE.md
- Documented all APM endpoints, Grafana dashboards, and alert rule files
- Added latency thresholds table (avg <500ms warn, P95 <1000ms warn, etc.)

## Acceptance Criteria Coverage
- Set up APM tools: PerformanceService middleware + record/dashboard/alerts/history endpoints
- Add performance metrics: Prometheus APM metrics exported at GET /metrics
- Create performance dashboards: apm.json Grafana dashboard provisioned automatically
- Implement alerting rules: alert_rules_performance.yml with 8 rules across latency/errors/throughput
- Include performance optimization: PERFORMANCE.md updated with APM endpoint reference and thresholds