### PR TITLE
feat(ui): implement theme system with dark/light mode and customization

### DIFF
--- a/client/src/lib/ThemeToggle.svelte
+++ b/client/src/lib/ThemeToggle.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { themeStore, accentColors, type AccentColor, type FontSize } from '$lib/theme';
+
+  let open = false;
+  const accents = Object.keys(accentColors) as AccentColor[];
+  const fontSizes: { value: FontSize; label: string }[] = [
+    { value: 'sm', label: 'Small' },
+    { value: 'md', label: 'Medium' },
+    { value: 'lg', label: 'Large' },
+  ];
+</script>
+
+<div class="relative">
+  <!-- Toggle dark/light -->
+  <button
+    on:click={() => themeStore.toggle()}
+    class="p-2 rounded-lg border border-[var(--accent)] text-[var(--accent)] hover:bg-[var(--accent)] hover:text-white transition-colors"
+    title="Toggle theme"
+    aria-label="Toggle dark/light mode"
+  >
+    {#if $themeStore.theme === 'dark'}☀️{:else}🌙{/if}
+  </button>
+
+  <!-- Settings gear -->
+  <button
+    on:click={() => (open = !open)}
+    class="ml-1 p-2 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+    title="Customize theme"
+    aria-label="Open theme settings"
+  >⚙️</button>
+
+  {#if open}
+  <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+  <div
+    class="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 z-50"
+    on:click|stopPropagation
+  >
+    <!-- Accent color -->
+    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">Accent</p>
+    <div class="flex gap-2 mb-4">
+      {#each accents as accent}
+        <button
+          on:click={() => themeStore.setAccent(accent)}
+          class="w-6 h-6 rounded-full border-2 transition-transform hover:scale-110"
+          style="background:{accentColors[accent].bg}; border-color:{$themeStore.accent === accent ? '#000' : 'transparent'}"
+          title={accent}
+          aria-label="Set accent to {accent}"
+        />
+      {/each}
+    </div>
+
+    <!-- Font size -->
+    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">Font Size</p>
+    <div class="flex gap-1">
+      {#each fontSizes as fs}
+        <button
+          on:click={() => themeStore.setFontSize(fs.value)}
+          class="flex-1 py-1 text-xs rounded-lg border transition-colors
+            {$themeStore.fontSize === fs.value
+              ? 'bg-[var(--accent)] text-white border-[var(--accent)]'
+              : 'border-gray-300 dark:border-gray-600 dark:text-gray-300 hover:border-[var(--accent)]'}"
+        >{fs.label}</button>
+      {/each}
+    </div>
+  </div>
+  {/if}
+</div>
+
+<!-- Close panel on outside click -->
+<svelte:window on:click={() => (open = false)} />

--- a/client/src/lib/theme.ts
+++ b/client/src/lib/theme.ts
@@ -1,0 +1,64 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export type Theme = 'light' | 'dark';
+export type AccentColor = 'indigo' | 'blue' | 'emerald' | 'violet' | 'rose';
+export type FontSize = 'sm' | 'md' | 'lg';
+
+export interface ThemePreferences {
+  theme: Theme;
+  accent: AccentColor;
+  fontSize: FontSize;
+}
+
+const STORAGE_KEY = 'stellar-escrow-theme';
+
+const defaults: ThemePreferences = { theme: 'light', accent: 'indigo', fontSize: 'md' };
+
+function loadPrefs(): ThemePreferences {
+  if (!browser) return defaults;
+  try {
+    return { ...defaults, ...JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}') };
+  } catch {
+    return defaults;
+  }
+}
+
+function createThemeStore() {
+  const { subscribe, set, update } = writable<ThemePreferences>(loadPrefs());
+
+  function persist(prefs: ThemePreferences) {
+    if (browser) localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    applyToDOM(prefs);
+  }
+
+  return {
+    subscribe,
+    setTheme: (theme: Theme) => update(p => { const n = { ...p, theme }; persist(n); return n; }),
+    setAccent: (accent: AccentColor) => update(p => { const n = { ...p, accent }; persist(n); return n; }),
+    setFontSize: (fontSize: FontSize) => update(p => { const n = { ...p, fontSize }; persist(n); return n; }),
+    toggle: () => update(p => { const n = { ...p, theme: p.theme === 'light' ? 'dark' : 'light' }; persist(n); return n; }),
+    init: () => { const prefs = loadPrefs(); set(prefs); persist(prefs); }
+  };
+}
+
+export const accentColors: Record<AccentColor, { bg: string; text: string; border: string }> = {
+  indigo: { bg: '#6366f1', text: '#6366f1', border: '#6366f1' },
+  blue:   { bg: '#3b82f6', text: '#3b82f6', border: '#3b82f6' },
+  emerald:{ bg: '#10b981', text: '#10b981', border: '#10b981' },
+  violet: { bg: '#8b5cf6', text: '#8b5cf6', border: '#8b5cf6' },
+  rose:   { bg: '#f43f5e', text: '#f43f5e', border: '#f43f5e' },
+};
+
+export const fontSizeMap: Record<FontSize, string> = { sm: '14px', md: '16px', lg: '18px' };
+
+export function applyToDOM(prefs: ThemePreferences) {
+  if (!browser) return;
+  const root = document.documentElement;
+  root.classList.toggle('dark', prefs.theme === 'dark');
+  const color = accentColors[prefs.accent].bg;
+  root.style.setProperty('--accent', color);
+  root.style.setProperty('--font-size-base', fontSizeMap[prefs.fontSize]);
+}
+
+export const themeStore = createThemeStore();

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -1,13 +1,33 @@
 <script lang="ts">
   import '../app.css';
+  import { onMount } from 'svelte';
+  import { themeStore } from '$lib/theme';
+  import ThemeToggle from '$lib/ThemeToggle.svelte';
+
+  onMount(() => themeStore.init());
 </script>
 
-<div class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-  <slot />
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200">
+  <header class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-3 flex items-center justify-between">
+    <a href="/" class="font-bold text-lg text-[var(--accent)]">StellarEscrow</a>
+    <ThemeToggle />
+  </header>
+  <main>
+    <slot />
+  </main>
 </div>
 
 <style global lang="postcss">
   @tailwind base;
   @tailwind components;
   @tailwind utilities;
+
+  :root {
+    --accent: #6366f1;
+    --font-size-base: 16px;
+  }
+
+  html {
+    font-size: var(--font-size-base);
+  }
 </style>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{html,js,svelte,ts}'],
+  darkMode: 'class',
   theme: {
     extend: {}
   },


### PR DESCRIPTION
closes #252 
## Changes

### New Files
- client/src/lib/theme.ts
  - Svelte writable store (themeStore) managing ThemePreferences
  - Persists preferences to localStorage under 'stellar-escrow-theme' key
  - applyToDOM() sets CSS custom properties (--accent, --font-size-base) and toggles the 'dark' class on <html> for Tailwind dark mode
  - Exports accentColors map and fontSizeMap for use in components

- client/src/lib/ThemeToggle.svelte
  - Moon/sun button to toggle dark ↔ light mode
  - Gear button opens a settings panel with:
    - 5 accent color swatches (indigo, blue, emerald, violet, rose)
    - Font size selector (Small / Medium / Large)
  - Panel closes on outside click via svelte:window

### Modified Files
- client/src/routes/+layout.svelte
  - Calls themeStore.init() on mount to restore saved preferences
  - Adds persistent header with StellarEscrow brand link and ThemeToggle
  - Applies dark: Tailwind variants to layout wrapper
  - Defines --accent and --font-size-base CSS variables as defaults

- client/tailwind.config.js
  - Enables darkMode: 'class' strategy

## Acceptance Criteria Met
- [x] Theme switching (dark/light toggle button)
- [x] Dark/light mode support via Tailwind 'class' dark mode
- [x] Color customization (5 accent color options)
- [x] Font size options (sm/md/lg mapped to 14/16/18px)
- [x] User preferences stored in localStorage