### PR TITLE
feat: add Samsung Internet to cross-browser testing matrix and compat…

### DIFF
--- a/frontend/compat.js
+++ b/frontend/compat.js
@@ -14,8 +14,9 @@
     var isBrave = !!(navigator.brave && typeof navigator.brave.isBrave === 'function');
     if (isBrave)              return { name: 'Brave',   version: (ua.match(/Chrome\/([\d.]+)/) || [])[1] };
     if (/Edg\//.test(ua))     return { name: 'Edge',    version: (ua.match(/Edg\/([\d.]+)/)    || [])[1] };
-    if (/OPR\//.test(ua))     return { name: 'Opera',   version: (ua.match(/OPR\/([\d.]+)/)    || [])[1] };
-    if (/Chrome\//.test(ua))  return { name: 'Chrome',  version: (ua.match(/Chrome\/([\d.]+)/) || [])[1] };
+    if (/OPR\//.test(ua))          return { name: 'Opera',            version: (ua.match(/OPR\/([\d.]+)/)           || [])[1] };
+    if (/SamsungBrowser\//.test(ua)) return { name: 'Samsung Internet', version: (ua.match(/SamsungBrowser\/([\d.]+)/) || [])[1] };
+    if (/Chrome\//.test(ua))       return { name: 'Chrome',            version: (ua.match(/Chrome\/([\d.]+)/)         || [])[1] };
     if (/Firefox\//.test(ua)) return { name: 'Firefox', version: (ua.match(/Firefox\/([\d.]+)/)|| [])[1] };
     if (/Safari\//.test(ua))  return { name: 'Safari',  version: (ua.match(/Version\/([\d.]+)/)|| [])[1] };
     if (/Trident\//.test(ua)) return { name: 'IE',      version: (ua.match(/rv:([\d.]+)/)      || [])[1] };
@@ -23,7 +24,7 @@
   })();
 
   // Minimum supported versions
-  var MIN_VERSIONS = { Chrome: 90, Firefox: 88, Safari: 14, Edge: 90, Opera: 76, Brave: 90 };
+  var MIN_VERSIONS = { Chrome: 90, Firefox: 88, Safari: 14, Edge: 90, Opera: 76, Brave: 90, 'Samsung Internet': 14 };
 
   var majorVersion = parseInt((browser.version || '0').split('.')[0], 10);
   var isSupported   = browser.name !== 'IE' &&
@@ -254,7 +255,7 @@
   }
 
   // Chrome / Edge / Brave: custom scrollbar styling if supported
-  var isChromium = /Chrome/.test(browser.name) || /Edge/.test(browser.name) || /Brave/.test(browser.name);
+  var isChromium = /Chrome/.test(browser.name) || /Edge/.test(browser.name) || /Brave/.test(browser.name) || browser.name === 'Samsung Internet';
   if (isChromium) {
     var scrollStyle = document.createElement('style');
     scrollStyle.textContent = [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * StellarEscrow — Cross-Browser Test Matrix
  *
  * Desktop: Chrome, Firefox, Safari (WebKit), Edge
- * Mobile:  Chrome Android (Pixel 5), Safari iOS (iPhone 12)
+ * Mobile:  Chrome Android (Pixel 5), Safari iOS (iPhone 12), Samsung Internet (Galaxy S9+)
  */
 export default defineConfig({
   testDir: './tests/browser',
@@ -50,6 +50,10 @@ export default defineConfig({
     {
       name: 'mobile-safari',
       use: { ...devices['iPhone 12'] },
+    },
+    {
+      name: 'mobile-samsung',
+      use: { ...devices['Galaxy S9+'] },
     },
   ],
 

--- a/tests/browser/browser-matrix.ts
+++ b/tests/browser/browser-matrix.ts
@@ -10,8 +10,9 @@ export const BROWSER_MATRIX = {
     { name: 'Edge',    minVersion: 90,  engine: 'chromium' },
   ],
   mobile: [
-    { name: 'Chrome Android', device: 'Pixel 5',   engine: 'chromium' },
-    { name: 'Safari iOS',     device: 'iPhone 12', engine: 'webkit'   },
+    { name: 'Chrome Android',   device: 'Pixel 5',    engine: 'chromium' },
+    { name: 'Safari iOS',       device: 'iPhone 12',  engine: 'webkit'   },
+    { name: 'Samsung Internet', device: 'Galaxy S9+', engine: 'chromium' },
   ],
 } as const;
 

--- a/tests/browser/mobile.spec.ts
+++ b/tests/browser/mobile.spec.ts
@@ -113,3 +113,31 @@ test.describe('Mobile browser — iOS Safari specific', () => {
     expect(overflow).toBe(false);
   });
 });
+
+test.describe('Mobile browser — Samsung Internet specific', () => {
+  test.use({ ...require('@playwright/test').devices['Galaxy S9+'] });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('page loads without JS errors on Samsung Internet', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('StellarCompat initialises on Samsung Internet', async ({ page }) => {
+    const compat = await page.evaluate(() => typeof (window as any).StellarCompat);
+    expect(compat).toBe('object');
+  });
+
+  test('no horizontal overflow on Galaxy S9+', async ({ page }) => {
+    const overflow = await page.evaluate(() =>
+      document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(overflow).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #342 
## Summary
  - Add Samsung Internet (Galaxy S9+) to the Playwright browser matrix as a 7th test project
  - Fix `compat.js` UA detection so Samsung Internet is no longer misidentified as Chrome
  - Add `'Samsung Internet': 14` to minimum version map and include it in Chromium-specific fixes
  - Add dedicated `test.describe` block with 3 tests in `mobile.spec.ts`

  ## Changes
  - `tests/browser/browser-matrix.ts` — new mobile entry: Samsung Internet / Galaxy S9+
  - `playwright.config.ts` — new project `mobile-samsung` using `devices['Galaxy S9+']`
  - `tests/browser/mobile.spec.ts` — Samsung Internet describe block (JS errors, StellarCompat init, no overflow)
  - `frontend/compat.js` — `SamsungBrowser/` guard, min version, `isChromium` flag
  ## Test plan
  - [ ] `npm run test:browser` passes across all 7 browser projects
  - [ ] `mobile-samsung` project runs the 3 new Samsung Internet tests
  - [ ] `StellarCompat.browser.name` returns `'Samsung Internet'` on Galaxy S9+ UA