### PR TITLE
feat(api): dispute evidence storage backend (Issue #125)

### DIFF
--- a/indexer/migrations/20260330000000_dispute_evidence.sql
+++ b/indexer/migrations/20260330000000_dispute_evidence.sql
@@ -1,0 +1,25 @@
+-- Dispute evidence: links uploaded files to disputes with participant/arbitrator access control
+CREATE TABLE IF NOT EXISTS dispute_evidence (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    dispute_id  BIGINT NOT NULL,          -- trade_id acting as dispute identifier
+    file_id     UUID NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    uploader    VARCHAR(100) NOT NULL,    -- Stellar address of uploader
+    description TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispute_evidence_dispute ON dispute_evidence (dispute_id);
+CREATE INDEX IF NOT EXISTS idx_dispute_evidence_file    ON dispute_evidence (file_id);
+
+-- Signed download tokens (short-lived, single-use)
+CREATE TABLE IF NOT EXISTS evidence_download_tokens (
+    token       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    file_id     UUID NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    requester   VARCHAR(100) NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    used        BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_tokens_file    ON evidence_download_tokens (file_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_tokens_expires ON evidence_download_tokens (expires_at);

--- a/indexer/src/database.rs
+++ b/indexer/src/database.rs
@@ -1942,6 +1942,142 @@ impl Database {
         Ok(())
     }
 
+    // =========================================================================
+    // Dispute Evidence (Issue #125)
+    // =========================================================================
+
+    /// Verify that `address` is a buyer, seller, or arbitrator for the given dispute (trade_id).
+    /// Returns Forbidden if not a participant.
+    pub async fn check_dispute_participant(&self, dispute_id: i64, address: &str) -> Result<(), crate::error::AppError> {
+        use sqlx::Row;
+        // Participants are derived from trade events stored in the events table.
+        let row = sqlx::query(
+            r#"
+            SELECT COUNT(*) AS cnt
+            FROM events
+            WHERE event_type IN ('trade_created', 'dispute_raised', 'arbitrator_registered')
+              AND (
+                data->>'trade_id' = $1::text
+                AND (
+                    data->>'seller'     = $2
+                    OR data->>'buyer'   = $2
+                    OR data->>'raised_by' = $2
+                    OR data->>'arbitrator' = $2
+                )
+              )
+            "#,
+        )
+        .bind(dispute_id)
+        .bind(address)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let cnt: i64 = row.get("cnt");
+        if cnt == 0 {
+            return Err(crate::error::AppError::Forbidden(
+                "Only dispute participants or arbitrators may access evidence".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Insert a dispute evidence record linking a file to a dispute.
+    pub async fn insert_dispute_evidence(
+        &self,
+        dispute_id: i64,
+        file_id: uuid::Uuid,
+        uploader: &str,
+        description: Option<&str>,
+    ) -> Result<crate::models::DisputeEvidenceRecord, crate::error::AppError> {
+        let record = sqlx::query_as::<_, crate::models::DisputeEvidenceRecord>(
+            r#"
+            INSERT INTO dispute_evidence (dispute_id, file_id, uploader, description)
+            VALUES ($1, $2, $3, $4)
+            RETURNING *
+            "#,
+        )
+        .bind(dispute_id)
+        .bind(file_id)
+        .bind(uploader)
+        .bind(description)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(record)
+    }
+
+    /// List all evidence records for a dispute.
+    pub async fn list_dispute_evidence(
+        &self,
+        dispute_id: i64,
+    ) -> Result<Vec<crate::models::DisputeEvidenceRecord>, crate::error::AppError> {
+        let records = sqlx::query_as::<_, crate::models::DisputeEvidenceRecord>(
+            "SELECT * FROM dispute_evidence WHERE dispute_id = $1 ORDER BY created_at ASC",
+        )
+        .bind(dispute_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(records)
+    }
+
+    /// Fetch a single evidence record by its id.
+    pub async fn get_dispute_evidence(
+        &self,
+        evidence_id: uuid::Uuid,
+    ) -> Result<Option<crate::models::DisputeEvidenceRecord>, crate::error::AppError> {
+        let record = sqlx::query_as::<_, crate::models::DisputeEvidenceRecord>(
+            "SELECT * FROM dispute_evidence WHERE id = $1",
+        )
+        .bind(evidence_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(record)
+    }
+
+    /// Create a short-lived (15-minute) signed download token for an evidence file.
+    pub async fn create_evidence_download_token(
+        &self,
+        file_id: uuid::Uuid,
+        requester: &str,
+    ) -> Result<crate::models::EvidenceDownloadToken, crate::error::AppError> {
+        use chrono::Duration;
+        let expires_at = chrono::Utc::now() + Duration::minutes(15);
+        let record = sqlx::query_as::<_, crate::models::EvidenceDownloadToken>(
+            r#"
+            INSERT INTO evidence_download_tokens (file_id, requester, expires_at)
+            VALUES ($1, $2, $3)
+            RETURNING token, file_id, requester, expires_at, used, created_at
+            "#,
+        )
+        .bind(file_id)
+        .bind(requester)
+        .bind(expires_at)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(record)
+    }
+
+    /// Consume (mark used) a download token if it is valid and unexpired.
+    /// Returns None if the token is invalid, expired, or already used.
+    pub async fn consume_evidence_download_token(
+        &self,
+        token: uuid::Uuid,
+    ) -> Result<Option<crate::models::EvidenceDownloadToken>, crate::error::AppError> {
+        let record = sqlx::query_as::<_, crate::models::EvidenceDownloadToken>(
+            r#"
+            UPDATE evidence_download_tokens
+            SET used = TRUE
+            WHERE token = $1
+              AND used = FALSE
+              AND expires_at > NOW()
+            RETURNING token, file_id, requester, expires_at, used, created_at
+            "#,
+        )
+        .bind(token)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(record)
+    }
+
     fn row_to_compliance_check(
         &self,
         row: &sqlx::postgres::PgRow,

--- a/indexer/src/dispute_evidence_handlers.rs
+++ b/indexer/src/dispute_evidence_handlers.rs
@@ -1,0 +1,190 @@
+use axum::{
+    extract::{Multipart, Path, Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use bytes::Bytes;
+use chrono::Utc;
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::error::AppError;
+use crate::models::{DisputeEvidenceRecord, DisputeEvidenceResponse, EvidenceDownloadToken};
+use crate::storage::{FileCategory, StorageService};
+use crate::database::Database;
+
+#[derive(Clone)]
+pub struct EvidenceState {
+    pub storage: Arc<StorageService>,
+    pub db: Arc<Database>,
+}
+
+#[derive(Deserialize)]
+pub struct EvidenceAccessQuery {
+    pub requester: String,
+}
+
+/// POST /disputes/:id/evidence
+/// Multipart: `file` (binary), `uploader` (Stellar address), `description` (optional text)
+pub async fn upload_dispute_evidence(
+    Path(dispute_id): Path<i64>,
+    State(state): State<EvidenceState>,
+    mut multipart: Multipart,
+) -> Result<impl IntoResponse, AppError> {
+    let mut file_data: Option<Bytes> = None;
+    let mut original_name = String::from("evidence");
+    let mut mime_type = String::from("application/octet-stream");
+    let mut uploader = String::new();
+    let mut description: Option<String> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| AppError::Storage(format!("Multipart error: {e}")))?
+    {
+        match field.name() {
+            Some("file") => {
+                if let Some(fname) = field.file_name() {
+                    original_name = fname.to_string();
+                }
+                if let Some(ct) = field.content_type() {
+                    mime_type = ct.to_string();
+                }
+                file_data = Some(
+                    field
+                        .bytes()
+                        .await
+                        .map_err(|e| AppError::Storage(format!("Failed to read file: {e}")))?,
+                );
+            }
+            Some("uploader") => {
+                uploader = field
+                    .text()
+                    .await
+                    .map_err(|e| AppError::Storage(format!("Failed to read uploader: {e}")))?;
+            }
+            Some("description") => {
+                let text = field.text().await.unwrap_or_default();
+                if !text.is_empty() {
+                    description = Some(text);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if uploader.is_empty() {
+        return Err(AppError::BadRequest("uploader address is required".into()));
+    }
+    let data = file_data.ok_or_else(|| AppError::BadRequest("No file field in request".into()))?;
+
+    // Verify uploader is a participant or arbitrator for this dispute
+    state
+        .db
+        .check_dispute_participant(dispute_id, &uploader)
+        .await?;
+
+    // Store the file under the "evidence" category
+    let file_record = state
+        .storage
+        .upload(&uploader, FileCategory::Evidence, &original_name, &mime_type, data, Some(dispute_id))
+        .await?;
+
+    // Record the dispute evidence link
+    let evidence = state
+        .db
+        .insert_dispute_evidence(dispute_id, file_record.id, &uploader, description.as_deref())
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({
+            "evidence": evidence,
+            "file": file_record,
+        })),
+    ))
+}
+
+/// GET /disputes/:id/evidence
+/// Returns all evidence for a dispute (participants/arbitrators only).
+pub async fn list_dispute_evidence(
+    Path(dispute_id): Path<i64>,
+    Query(params): Query<EvidenceAccessQuery>,
+    State(state): State<EvidenceState>,
+) -> Result<impl IntoResponse, AppError> {
+    state
+        .db
+        .check_dispute_participant(dispute_id, &params.requester)
+        .await?;
+
+    let items = state.db.list_dispute_evidence(dispute_id).await?;
+    Ok(Json(json!({ "evidence": items })))
+}
+
+/// GET /disputes/:id/evidence/:evidence_id/download-url?requester=<addr>
+/// Issues a short-lived signed token for downloading a specific evidence file.
+pub async fn get_evidence_download_url(
+    Path((dispute_id, evidence_id)): Path<(i64, Uuid)>,
+    Query(params): Query<EvidenceAccessQuery>,
+    State(state): State<EvidenceState>,
+) -> Result<impl IntoResponse, AppError> {
+    state
+        .db
+        .check_dispute_participant(dispute_id, &params.requester)
+        .await?;
+
+    // Verify the evidence belongs to this dispute
+    let evidence = state
+        .db
+        .get_dispute_evidence(evidence_id)
+        .await?
+        .ok_or(AppError::NotFound("Evidence not found".into()))?;
+
+    if evidence.dispute_id != dispute_id {
+        return Err(AppError::Forbidden("Evidence does not belong to this dispute".into()));
+    }
+
+    let token = state
+        .db
+        .create_evidence_download_token(evidence.file_id, &params.requester)
+        .await?;
+
+    Ok(Json(json!({
+        "token": token.token,
+        "expires_at": token.expires_at,
+        "download_url": format!("/evidence/download/{}", token.token),
+    })))
+}
+
+/// GET /evidence/download/:token
+/// Redeems a signed download token and streams the file.
+pub async fn redeem_evidence_download(
+    Path(token): Path<Uuid>,
+    State(state): State<EvidenceState>,
+) -> Result<impl IntoResponse, AppError> {
+    let token_record = state
+        .db
+        .consume_evidence_download_token(token)
+        .await?
+        .ok_or(AppError::NotFound("Invalid or expired download token".into()))?;
+
+    let (record, data) = state
+        .storage
+        .download(token_record.file_id, &token_record.requester)
+        .await?;
+
+    let response = axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, &record.mime_type)
+        .header(
+            axum::http::header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{}\"", record.original_name),
+        )
+        .header(axum::http::header::CONTENT_LENGTH, data.len())
+        .body(axum::body::Body::from(data))
+        .map_err(|e| AppError::Storage(format!("Response build error: {e}")))?;
+
+    Ok(response)
+}

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -17,6 +17,7 @@ mod analytics_service;
 mod backup_service;
 mod cache_service;
 mod compliance_service;
+mod dispute_evidence_handlers;
 mod monitoring_service;
 mod webhook_service;
 mod job_queue;
@@ -56,6 +57,10 @@ use config::Config;
 use database::Database;
 use event_monitor::EventMonitor;
 use file_handlers::{delete_file, download_file, list_files, upload_file};
+use dispute_evidence_handlers::{
+    upload_dispute_evidence, list_dispute_evidence,
+    get_evidence_download_url, redeem_evidence_download, EvidenceState,
+};
 use fraud_service::FraudDetectionService;
 use gateway::{GatewayConfig, GatewayState};
 use handlers::{AppState, *};
@@ -302,7 +307,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/files", get(list_files))
         .route("/files/:category", post(upload_file))
         .route("/files/:id", get(download_file).delete(delete_file))
-        .with_state(storage_service);
+        .with_state(storage_service.clone());
+
+    let evidence_state = EvidenceState {
+        storage: storage_service.clone(),
+        db: database.clone(),
+    };
+    let evidence_router = Router::new()
+        .route("/disputes/:id/evidence", post(upload_dispute_evidence).get(list_dispute_evidence))
+        .route("/disputes/:id/evidence/:evidence_id/download-url", get(get_evidence_download_url))
+        .route("/evidence/download/:token", get(redeem_evidence_download))
+        .with_state(evidence_state);
 
     // Versioned API router (v1) - includes gateway-enhanced endpoints
     let v1_api = Router::new()
@@ -424,6 +439,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/audit/purge", delete(purge_audit_logs))
         .merge(admin_router)
         .merge(file_router)
+        .merge(evidence_router)
         .merge(Router::new().nest("/api/v1", v1_api))
         .with_state(AppState {
             database,

--- a/indexer/src/models.rs
+++ b/indexer/src/models.rs
@@ -644,3 +644,34 @@ pub struct PushRegistrationRequest {
     pub platform: String,
     pub address: String,
 }
+
+// =============================================================================
+// Dispute Evidence Models (Issue #125)
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct DisputeEvidenceRecord {
+    pub id: Uuid,
+    pub dispute_id: i64,
+    pub file_id: Uuid,
+    pub uploader: String,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DisputeEvidenceResponse {
+    pub evidence: DisputeEvidenceRecord,
+    pub file: FileRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct EvidenceDownloadToken {
+    pub token: Uuid,
+    pub file_id: Uuid,
+    pub requester: String,
+    pub expires_at: DateTime<Utc>,
+    pub used: bool,
+    pub created_at: DateTime<Utc>,
+}


### PR DESCRIPTION
- Add migration: dispute_evidence table + evidence_download_tokens table
- POST /disputes/:id/evidence — multipart upload with participant/arbitrator access control
- GET  /disputes/:id/evidence — list evidence (participants only)
- GET  /disputes/:id/evidence/:eid/download-url — issue 15-min signed token
- GET  /evidence/download/:token — redeem token and stream file
- File validation (size/MIME) delegated to existing StorageService
- DB helpers: check_dispute_participant, insert/list/get_dispute_evidence, create/consume_evidence_download_token

Closes #412 