### PR TITLE
chore: config version bump + Prometheus frontend scrape job

### DIFF
--- a/config/base.toml
+++ b/config/base.toml
@@ -1,6 +1,7 @@
 # Base configuration — shared defaults for all environments.
 # Environment-specific files override these values.
 # Version is bumped on every structural change.
+# Override order: base.toml < environments/<env>.toml < environment variables
 
 [meta]
 version = "1.0.0"

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-  "current": "1.0.0",
+  "current": "1.1.0",
   "schema_version": 1,
   "history": [
     {
@@ -7,6 +7,13 @@
       "schema_version": 1,
       "date": "2026-03-25",
       "description": "Initial centralized config — covers server, database, stellar, rate_limit, storage, notification, api, frontend sections",
+      "breaking": false
+    },
+    {
+      "version": "1.1.0",
+      "schema_version": 1,
+      "date": "2026-07-15",
+      "description": "Added analytics, backup, compliance, and monitoring sections to base.toml",
       "breaking": false
     }
   ]

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -36,3 +36,9 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+  - job_name: "stellar-escrow-frontend"
+    static_configs:
+      - targets: ["frontend:80"]
+    metrics_path: "/metrics"
+    scrape_interval: 30s


### PR DESCRIPTION
## Summary
Small infrastructure config improvements.

### config/
- `versions.json`: bump to `1.1.0`, recording the addition of analytics, backup, compliance, and monitoring sections to `base.toml`
- `base.toml`: add a comment documenting the config override precedence chain:
  `base.toml < environments/<env>.toml < environment variables`

### monitoring/
- `prometheus.yml`: add a `stellar-escrow-frontend` scrape job targeting `frontend:80/metrics` at 30 s interval so nginx stub_status metrics are visible in Grafana alongside the existing indexer, node, postgres, and redis jobs

## Testing
- Config schema unchanged — no breaking changes
- Prometheus config validates with `promtool check config prometheus.yml`