### PR TITLE
feat: Button JSDoc + stripControlChars sanitization utility

### DIFF
--- a/components/src/base/Button.tsx
+++ b/components/src/base/Button.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import './Button.css';
 
+/**
+ * Button — base interactive element used throughout StellarEscrow.
+ *
+ * Variants: primary | secondary | danger | success
+ * Sizes:    sm | md | lg
+ *
+ * Shows a spinner and sets aria-busy when `loading` is true.
+ * Forwards refs so it can be composed with tooltip/popover libraries.
+ */
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger' | 'success';
   size?: 'sm' | 'md' | 'lg';

--- a/security/src/sanitization.ts
+++ b/security/src/sanitization.ts
@@ -44,3 +44,12 @@ export const validateUrl = (url: string): boolean => {
 export const validateAddress = (address: string): boolean => {
   return /^G[A-Z2-7]{55}$/.test(address);
 };
+
+/**
+ * Strip ASCII control characters (U+0000–U+001F, U+007F) from a string.
+ * Useful for sanitizing user-supplied text before storage or display.
+ */
+export const stripControlChars = (input: string): string => {
+  // eslint-disable-next-line no-control-regex
+  return input.replace(/[\x00-\x1F\x7F]/g, '');
+};


### PR DESCRIPTION
## Summary
Small improvements to shared component and security libraries.

### components/
- `Button.tsx`: add a JSDoc comment documenting variants (`primary | secondary | danger | success`), sizes (`sm | md | lg`), loading/aria-busy behaviour, and ref-forwarding. Shows up in IDE tooltips and Storybook autodocs.

### security/
- `sanitization.ts`: add `stripControlChars(input: string): string` — removes ASCII control characters (U+0000–U+001F, U+007F) from strings before storage or display. Complements the existing `sanitizeInput` and `escapeHtml` helpers and is useful for cleaning user-supplied text fields.

## Testing
- Button renders correctly in all existing tests — no logic changed
- `stripControlChars` strips tab, newline, carriage return, and DEL characters and leaves printable characters unchanged