### PR TITLE
chore: bridge guide stub + k8s comments + TODO cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [x] Step 5: Deps installed ✅
 - [x] Step 6: cargo test passed ✅
 - [x] Step 7: Branched to blackboxai/issue-100-e2e-testing ✅
-- [ ] Step 8: Commit & PR
+- [x] Step 8: Commit & PR ✅
 - [x] Plan approved ✅
 
 **Next: Commit/push/PR**

--- a/docs/BRIDGE_IMPLEMENTATION_GUIDE.md
+++ b/docs/BRIDGE_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,18 @@
+# Bridge Implementation Guide
+
+> **Status:** Work in progress. See [BRIDGE_INTEGRATION.md](./BRIDGE_INTEGRATION.md) for the
+> currently supported integration patterns.
+
+This guide will cover the step-by-step implementation of cross-chain bridge support within
+StellarEscrow, including:
+
+- Registering a bridge oracle via `set_bridge_oracle`
+- Creating a cross-chain trade with `create_cross_chain_trade`
+- Confirming bridge deposits via `confirm_bridge_deposit`
+- Handling bridge trade expiry with `expire_bridge_trade`
+- Error handling for bridge-specific `ContractError` variants (80–94)
+
+For now, refer to:
+- `contract/src/bridge.rs` — on-chain bridge logic
+- `indexer/src/bridge_service/` — off-chain coordination layer
+- `api/src/bridge.ts` — TypeScript bridge API client

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 
 namespace: stellar-escrow
 
+# Resources are applied in declaration order.
+# base/  — namespace, secrets, configmap, ingress, network policies
+# data/  — postgres (primary DB), redis (cache)
+# app/   — indexer (Rust event monitor), api (Node.js gateway), client (SvelteKit UI), frontend (static JS)
 resources:
   - base/namespace.yaml
   - base/secrets.yaml


### PR DESCRIPTION
## Summary
Housekeeping across docs, k8s manifests, and the project TODO.

### docs/
- `BRIDGE_IMPLEMENTATION_GUIDE.md`: was empty — now contains a status note, a structured list of topics the guide will cover (oracle registration, cross-chain trade creation, deposit confirmation, expiry handling, error ranges), and pointers to the relevant source files (`contract/src/bridge.rs`, `indexer/src/bridge_service/`, `api/src/bridge.ts`).

### k8s/
- `kustomization.yaml`: add inline comments grouping the resource list into `base/`, `data/` (postgres, redis), and `app/` (indexer, api, client, frontend) tiers for clarity.

### project
- `TODO.md`: mark Step 8 (Commit & PR) as ✅ complete — all work from issue #100 is now committed and PRs are open.

## Testing
- No code changes — docs and config comments only