### PR TITLE
feat: trade count in dashboard header + success color in theme

### DIFF
--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -46,6 +46,11 @@ export default function Dashboard() {
         >
           <h1 id="dashboard-title" style={{ fontSize: '1.5rem' }}>
             Trades
+            {trades.length > 0 && (
+              <span style={{ fontSize: '0.9rem', fontWeight: 400, color: '#666', marginLeft: '0.5rem' }}>
+                ({trades.length})
+              </span>
+            )}
           </h1>
 
           <Link

--- a/app/src/theme.ts
+++ b/app/src/theme.ts
@@ -1,9 +1,14 @@
 import { createTheme } from '@mui/material/styles';
 
+// StellarEscrow brand palette
+// primary   #1a1a2e  — deep navy
+// secondary #e94560  — coral red (actions, alerts)
+// success   #2ecc71  — green (funded, completed states)
 const theme = createTheme({
   palette: {
     primary: { main: '#1a1a2e' },
     secondary: { main: '#e94560' },
+    success: { main: '#2ecc71' },
     background: { default: '#f5f5f5' },
   },
   typography: {


### PR DESCRIPTION
## Summary

### app/src/pages/Dashboard.tsx
- Display trade count next to the 'Trades' heading (e.g. `Trades (5)`) using a muted inline span
- Count is hidden when the list is empty, keeping the UI clean

### app/src/theme.ts
- Add `success: { main: '#2ecc71' }` to the MUI palette for funded/completed trade states
- Add inline brand palette comments so designers can find hex values at a glance

## Testing
- No logic changes to data fetching — purely presentational
- Existing snapshot and unit tests are unaffected