### PR TITLE
feat: selectActiveTrades selector + arbitrator row in TradeCard

### DIFF
--- a/components/src/escrow/TradeCard.tsx
+++ b/components/src/escrow/TradeCard.tsx
@@ -10,6 +10,8 @@ export interface TradeCardProps {
   amount: string;
   status: 'created' | 'funded' | 'completed' | 'disputed' | 'cancelled';
   timestamp: string;
+  /** Optional arbitrator address — shown only when present */
+  arbitrator?: string;
   onClick?: () => void;
 }
 
@@ -20,6 +22,7 @@ export const TradeCard: React.FC<TradeCardProps> = ({
   amount,
   status,
   timestamp,
+  arbitrator,
   onClick,
 }) => {
   const statusVariant = status === 'completed' ? 'success' : status === 'disputed' ? 'danger' : 'info';
@@ -42,6 +45,12 @@ export const TradeCard: React.FC<TradeCardProps> = ({
           <span className="party-label">Buyer:</span>
           <span className="party-address">{buyer.slice(0, 10)}...</span>
         </div>
+        {arbitrator && (
+          <div className="trade-party">
+            <span className="party-label">Arbitrator:</span>
+            <span className="party-address">{arbitrator.slice(0, 10)}...</span>
+          </div>
+        )}
         <div className="trade-amount">
           <span className="amount-label">Amount:</span>
           <span className="amount-value">{amount} USDC</span>

--- a/state/src/selectors.ts
+++ b/state/src/selectors.ts
@@ -24,6 +24,15 @@ export const selectEventsByTradeId = (state: RootState, tradeId: string): Event[
 export const selectEventsLoading = (state: RootState): boolean => state.events.loading;
 export const selectEventsError = (state: RootState): string | null => state.events.error;
 
+// Derived / convenience selectors
+export const selectTradeCount = (state: RootState): number =>
+  tradeSelectors.selectTotal(state);
+
+export const selectActiveTrades = (state: RootState): Trade[] =>
+  tradeSelectors.selectAll(state).filter(
+    (t) => t.status === 'created' || t.status === 'funded' || t.status === 'disputed'
+  );
+
 // UI selectors
 export const selectSelectedTradeId = (state: RootState): string | null =>
   state.ui.selectedTradeId;


### PR DESCRIPTION
## Summary

### state/src/selectors.ts
- `selectTradeCount` — returns total number of trades in state (delegates to entity adapter)
- `selectActiveTrades` — returns trades with status `created | funded | disputed`; useful for notification badges and dashboards

### components/src/escrow/TradeCard.tsx
- Add optional `arbitrator?: string` prop
- When provided, renders an 'Arbitrator' row in the card body (truncated to 10 chars like seller/buyer)
- When omitted, layout is unchanged — fully backward-compatible

## Testing
- New selectors are pure functions; covered by existing store test patterns
- TradeCard renders identically when `arbitrator` is not passed