### PR TITLE
test: add completedEscrow and disputedEscrow factory helpers

### DIFF
--- a/tests/factories/escrowFactory.ts
+++ b/tests/factories/escrowFactory.ts
@@ -48,3 +48,13 @@ export function escrowList(n: number, overrides: Partial<EscrowRecord> = {}): Es
 export function resetEscrowSeq(start = 1): void {
   _tradeIdSeq = start;
 }
+
+/** Convenience: create an escrow already in `completed` status */
+export function completedEscrow(overrides: Partial<EscrowRecord> = {}): EscrowRecord {
+  return escrowFactory({ status: 'completed', ...overrides });
+}
+
+/** Convenience: create an escrow in `disputed` status with an arbitrator set */
+export function disputedEscrow(overrides: Partial<EscrowRecord> = {}): EscrowRecord {
+  return escrowFactory({ status: 'disputed', arbitrator: overrides.arbitrator ?? stellarAddress(), ...overrides });
+}


### PR DESCRIPTION
## Summary

Adds two convenience wrappers to `tests/factories/escrowFactory.ts`:

- `completedEscrow(overrides?)` — creates an escrow with `status: 'completed'`
- `disputedEscrow(overrides?)` — creates an escrow with `status: 'disputed'` and an auto-generated arbitrator address (overridable)

Both delegate to `escrowFactory` so all existing override patterns continue to work. Reduces repetitive `escrowFactory({ status: 'completed' })` calls scattered across test suites.

## Testing
- No changes to existing factory behaviour
- New helpers are thin wrappers — no additional test coverage needed