### PR TITLE
fix: reconstruct the escrow contract crate from merge corruption

### DIFF
--- a/contract/src/bridge.rs
+++ b/contract/src/bridge.rs
@@ -258,7 +258,7 @@ pub fn create_cross_chain_trade(
     let cross_chain_trade = CrossChainTrade {
         trade_id,
         source_chain,
-        dest_chain: String::from_small_copy(env, "stellar"),
+        dest_chain: String::from_str(env, "stellar"),
         source_tx_hash,
         bridge_provider,
         attestation_id,
@@ -332,7 +332,7 @@ pub fn validate_bridge_attestation(
         return Ok(BridgeValidation {
             valid: false,
             error_code: Some(1),
-            error_message: Some(String::from_small_copy(env, "Invalid signature")),
+            error_message: Some(String::from_str(env, "Invalid signature")),
             confirmations: 0,
         });
     }
@@ -344,7 +344,7 @@ pub fn validate_bridge_attestation(
         return Ok(BridgeValidation {
             valid: false,
             error_code: Some(2),
-            error_message: Some(String::from_small_copy(env, "Amount out of range")),
+            error_message: Some(String::from_str(env, "Amount out of range")),
             confirmations: 0,
         });
     }
@@ -358,7 +358,7 @@ pub fn validate_bridge_attestation(
         return Ok(BridgeValidation {
             valid: false,
             error_code: Some(3),
-            error_message: Some(String::from_small_copy(env, "Attestation already processed")),
+            error_message: Some(String::from_str(env, "Attestation already processed")),
             confirmations: 0,
         });
     }

--- a/contract/src/errors.rs
+++ b/contract/src/errors.rs
@@ -3,12 +3,13 @@ use soroban_sdk::contracterror;
 /// Enumeration of all contract-level errors.
 /// Each variant maps to a unique `u32` discriminant returned to the caller.
 /// Ranges:
-///   1–33   Core escrow errors
-///   40–44  Oracle errors
-///   50–54  AMM errors
-///   60–66  Upgrade system errors
-///   70–74  Multi-sig arbitration errors
-///   80–94  Bridge errors
+///   1–39    Core escrow / tier / template / subscription / governance / privacy errors
+///   40–44   Oracle errors
+///   50–54   AMM errors (amm.rs is not currently wired into the contract)
+///   60–66   Upgrade system errors
+///   70–74   Multi-sig arbitration errors
+///   80–94   Bridge errors
+///   110–119 Price-trigger errors
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -38,74 +39,54 @@ pub enum ContractError {
     MigrationAlreadyApplied = 23,
     MigrationVersionMismatch = 24,
     BridgeOracleNotSet = 25,
-    BridgeTradeExpired = 26,
-    BridgeTradeNotExpired = 27,
-    InsuranceProviderNotRegistered = 28,
-    InsurancePremiumTooHigh = 29,
-    TradeNotInsured = 30,
-    InsuranceAlreadyClaimed = 31,
-    InsuranceClaimNotEligible = 32,
-    InvalidSplitBps = 33,
-    // Metadata errors (duplicates removed)
-    InvalidTierConfig = 14,
-    TierNotFound = 15,
-    TemplateNotFound = 16,
-    TemplateInactive = 17,
-    TemplateNameTooLong = 18,
-    TemplateVersionLimitExceeded = 19,
-    TemplateAmountMismatch = 20,
-    SubscriptionNotFound = 21,
-    SubscriptionExpired = 22,
-    SubscriptionAlreadyActive = 23,
-    ProposalNotFound = 24,
-    ProposalNotActive = 25,
-    AlreadyVoted = 26,
-    InsufficientVotingPower = 27,
-    ProposalNotPassed = 28,
-    ProposalAlreadyExecuted = 29,
-    VotingEnded = 30,
-    PrivacyDataTooLong = 31,
-    DisclosureGrantNotFound = 32,
-    DisclosureUnauthorized = 33,
-    MigrationAlreadyApplied = 21,
-    MigrationVersionMismatch = 22,
-    BridgeOracleNotSet = 23,
-    BridgeTradeExpired = 24,
-    BridgeTradeNotExpired = 25,
     InsuranceProviderNotRegistered = 26,
     InsurancePremiumTooHigh = 27,
     TradeNotInsured = 28,
     InsuranceAlreadyClaimed = 29,
     InsuranceClaimNotEligible = 30,
-    // Oracle errors (40–44)
-    OracleNotFound = 40,
-    OracleAlreadyRegistered = 41,
-    OracleListFull = 42,
-    OracleUnavailable = 43,
-    OraclePriceInvalid = 44,
-    // AMM errors (50–54)
-    AmmPoolNotFound = 50,
-    // Bridge errors (80–99)
-    BridgeProviderNotFound = 80,
-    BridgeProviderAlreadyRegistered = 81,
-    BridgeProviderLimitExceeded = 82,
-    BridgeTradeNotFound = 83,
-    BridgeTradeExpired = 84,
-    BridgeTradeNotExpired = 85,
-    BridgeRetryLimitExceeded = 86,
-    BridgeAttestationInvalid = 87,
-    BridgeAttestationExpired = 88,
-    BridgeAmountOutOfRange = 89,
-    BridgeChainNotSupported = 90,
-    BridgeOracleNotAuthorized = 91,
-    BridgePaused = 92,
-    BridgeSignatureInvalid = 93,
-    BridgeNonceAlreadyUsed = 94,
-    AmmSlippageExceeded = 51,
-    AmmInsufficientShares = 52,
-    AmmInvalidPair = 53,
-    AmmPoolAlreadyExists = 54,
-    // Upgrade system errors (60–66)
+    InvalidSplitBps = 31,
+    InvalidRating = 32,
+    AlreadyRated = 33,
+    // Tiers / templates / subscriptions (not all currently exposed as contract
+    // entry points — see reconstruction notes)
+    InvalidTierConfig = 34,
+    TierNotFound = 35,
+    TemplateNotFound = 36,
+    TemplateInactive = 37,
+    TemplateNameTooLong = 38,
+    TemplateVersionLimitExceeded = 39,
+    TemplateAmountMismatch = 40,
+    SubscriptionNotFound = 41,
+    SubscriptionExpired = 42,
+    SubscriptionAlreadyActive = 43,
+    // Governance (governance.rs is not currently wired into the contract)
+    ProposalNotFound = 44,
+    ProposalNotActive = 45,
+    InsufficientVotingPower = 46,
+    ProposalNotPassed = 47,
+    ProposalAlreadyExecuted = 48,
+    VotingEnded = 49,
+    // Privacy (privacy.rs is not currently wired into the contract)
+    PrivacyDataTooLong = 50,
+    DisclosureGrantNotFound = 51,
+    DisclosureUnauthorized = 52,
+    // Social (social.rs is not currently wired into the contract)
+    CannotFollowSelf = 53,
+    NotFollowing = 54,
+    // Oracle errors (40–44 in the doc comment above collide with the core
+    // range that grew past 39; kept in a dedicated 100s block instead)
+    OracleNotFound = 100,
+    OracleAlreadyRegistered = 101,
+    OracleListFull = 102,
+    OracleUnavailable = 103,
+    OraclePriceInvalid = 104,
+    // AMM errors (amm.rs is not currently wired into the contract)
+    AmmPoolNotFound = 120,
+    AmmSlippageExceeded = 121,
+    AmmInsufficientShares = 122,
+    AmmInvalidPair = 123,
+    AmmPoolAlreadyExists = 124,
+    // Upgrade system errors
     /// An upgrade is already in progress (guard is set).
     UpgradeInProgress = 60,
     /// No upgrade proposal exists to execute or cancel.
@@ -127,9 +108,23 @@ pub enum ContractError {
     VotingNotExpired = 73,
     /// No consensus reached among arbitrators.
     NoConsensus = 74,
-    // Social feature errors (70-74)
-    CannotFollowSelf = 70,
-    NotFollowing = 71,
-    NoTrigger = 113,
-    PriceConditionNotMet = 114,
+    // Bridge errors (80–94)
+    BridgeProviderNotFound = 80,
+    BridgeProviderAlreadyRegistered = 81,
+    BridgeProviderLimitExceeded = 82,
+    BridgeTradeNotFound = 83,
+    BridgeTradeExpired = 84,
+    BridgeTradeNotExpired = 85,
+    BridgeRetryLimitExceeded = 86,
+    BridgeAttestationInvalid = 87,
+    BridgeAttestationExpired = 88,
+    BridgeAmountOutOfRange = 89,
+    BridgeChainNotSupported = 90,
+    BridgeOracleNotAuthorized = 91,
+    BridgePaused = 92,
+    BridgeSignatureInvalid = 93,
+    BridgeNonceAlreadyUsed = 94,
+    // Price triggers
+    NoTrigger = 110,
+    PriceConditionNotMet = 111,
 }

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -1,72 +1,7 @@
-use soroban_sdk::{Address, Env, String};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
 
-use crate::types::DisputeResolution;
-
-pub fn emit_arbitrator_registered(_env: &Env, _arbitrator: Address) {}
-pub fn emit_arbitrator_removed(_env: &Env, _arbitrator: Address) {}
-pub fn emit_fee_updated(_env: &Env, _fee_bps: u32) {}
-pub fn emit_compliance_failed(_env: &Env, _user: Address, _reason: &String) {}
-pub fn emit_compliance_updated(_env: &Env, _user: Address) {}
-pub fn emit_trade_created(
-    _env: &Env,
-    _trade_id: u64,
-    _seller: Address,
-    _buyer: Address,
-    _amount: u64,
-    _currency: Address,
-) {
-}
-pub fn emit_compliance_passed(
-    _env: &Env,
-    _trade_id: u64,
-    _seller: Address,
-    _buyer: Address,
-    _amount: u64,
-) {
-}
-pub fn emit_trade_funded(_env: &Env, _trade_id: u64) {}
-pub fn emit_trade_completed(_env: &Env, _trade_id: u64) {}
-pub fn emit_trade_confirmed(_env: &Env, _trade_id: u64, _payout: u64, _fee: u64) {}
-pub fn emit_dispute_raised(_env: &Env, _trade_id: u64, _raised_by: Address) {}
-pub fn emit_dispute_resolved(
-    _env: &Env,
-    _trade_id: u64,
-    _resolution: DisputeResolution,
-    _recipient: Address,
-) {
-}
-pub fn emit_partial_resolved(
-    _env: &Env,
-    _trade_id: u64,
-    _buyer_amount: u64,
-    _seller_amount: u64,
-    _fee: u64,
-) {
-}
-pub fn emit_trade_cancelled(_env: &Env, _trade_id: u64) {}
-pub fn emit_fees_withdrawn(_env: &Env, _amount: u64, _to: Address) {}
-pub fn emit_paused(_env: &Env, _admin: Address) {}
-pub fn emit_unpaused(_env: &Env, _admin: Address) {}
-pub fn emit_bridge_oracle_set(_env: &Env, _oracle: Address) {}
-pub fn emit_bridge_trade_created(_env: &Env, _trade_id: u64, _source_chain: String) {}
-pub fn emit_bridge_deposit_confirmed(_env: &Env, _trade_id: u64) {}
-pub fn emit_bridge_trade_expired(_env: &Env, _trade_id: u64) {}
-pub fn emit_insurance_provider_registered(_env: &Env, _provider: Address) {}
-pub fn emit_insurance_provider_removed(_env: &Env, _provider: Address) {}
-pub fn emit_insurance_purchased(
-    _env: &Env,
-    _trade_id: u64,
-    _provider: Address,
-    _premium: u64,
-    _coverage: u64,
-) {
-}
-pub fn emit_insurance_claimed(_env: &Env, _trade_id: u64, _payout: u64, _recipient: Address) {}
-pub fn emit_migrated(_env: &Env, _from_version: u32, _to_version: u32) {}
 /// Current event schema version. Bump when payload fields change.
 pub const EVENT_VERSION: u32 = 2;
-
-use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
 
 use crate::types::{DisputeResolution, SubscriptionTier, UserTier};
 
@@ -172,8 +107,6 @@ pub struct EvBridgeProviderRegistered { pub v: u32, pub provider: String, pub or
 #[contracttype] #[derive(Clone, Debug)]
 pub struct EvBridgeProviderDeactivated { pub v: u32, pub provider: String }
 #[contracttype] #[derive(Clone, Debug)]
-pub struct EvBridgeTradeCreated { pub v: u32, pub trade_id: u64, pub source_chain: String, pub source_tx_hash: String, pub bridge_provider: String }
-#[contracttype] #[derive(Clone, Debug)]
 pub struct EvBridgeAttestationReceived { pub v: u32, pub trade_id: u64, pub attestation_id: String, pub status: String }
 #[contracttype] #[derive(Clone, Debug)]
 pub struct EvBridgeAttestationConfirmed { pub v: u32, pub trade_id: u64, pub confirmations: u32 }
@@ -262,12 +195,6 @@ pub fn emit_compliance_updated(env: &Env, user: Address) {
         (cat_compliance(), symbol_short!("updated")),
         EvComplianceUpdated { v: EVENT_VERSION, user },
     );
-pub fn emit_compliance_failed(env: &Env, user: Address, reason: &soroban_sdk::String) {
-    env.events().publish((cat_sys(), symbol_short!("compl_fail")), EvComplianceFailed { v: EVENT_VERSION, user, reason: reason.clone() });
-}
-
-pub fn emit_compliance_passed(env: &Env, trade_id: u64, seller: Address, buyer: Address, amount: u64) {
-    env.events().publish((cat_sys(), symbol_short!("compl_pass")), EvCompliancePassed { v: EVENT_VERSION, trade_id, seller, buyer, amount });
 }
 
 pub fn emit_trade_funded(env: &Env, trade_id: u64) {
@@ -458,19 +385,6 @@ pub fn emit_oracle_unavailable(env: &Env, base: Address, quote: Address) {
 pub fn emit_trigger_executed(env: &Env, trade_id: u64, action: &crate::types::TriggerAction) {
     env.events().publish((cat_oracle(), symbol_short!("trig_ex")), EvTriggerExecuted { v: EVENT_VERSION, trade_id, action: action.clone() });
 }
-
-// ---------------------------------------------------------------------------
-// Upgrade system events
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Compliance event payloads
-// ---------------------------------------------------------------------------
-
-#[contracttype] #[derive(Clone, Debug)]
-pub struct EvComplianceFailed  { pub v: u32, pub user: Address, pub reason: String }
-#[contracttype] #[derive(Clone, Debug)]
-pub struct EvCompliancePassed  { pub v: u32, pub trade_id: u64, pub seller: Address, pub buyer: Address, pub amount: u64 }
 
 // ---------------------------------------------------------------------------
 // Upgrade system events

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -7,14 +7,18 @@ mod analytics;
 mod errors;
 mod events;
 mod storage;
-pub mod types;
+mod types;
 mod subscription;
 mod templates;
 mod tiers;
-mod types;
 mod upgrade;
 mod proxy;
 mod insurance;
+mod multisig;
+mod reputation;
+mod queries;
+mod oracle;
+mod bridge;
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
 
@@ -24,36 +28,17 @@ pub use analytics::{
 };
 pub use errors::ContractError;
 pub use types::{
-    ArbitrationConfig, ArbitratorReputation, ArbitratorVote, DisclosureGrant, DisputeResolution,
-    InsurancePolicy, MultiSigConfig, Proposal, ProposalAction, ProposalStatus, Subscription,
-    SubscriptionTier, TierConfig, TemplateTerms, TemplateVersion, Trade, TradePrivacy,
-    TradeStatus, TradeTemplate, UserTier, UserTierInfo, VotingSummary,
-    SubscriptionTier, TierConfig, TierStatus, TierThresholds, TemplateTerms, TemplateVersion,
-    Trade, TradePrivacy, TradeStatus, TradeTemplate, UserTier, UserTierInfo, VotingSummary,
-    ArbitrationConfig, CrossChainInfo, DisputeResolution, InsurancePolicy, KycStatus,
-    OptionalMetadata, Trade, TradeStatus, UserCompliance, MAX_INSURANCE_PREMIUM_BPS,
-    MAX_METADATA_SIZE,
-    ArbitrationConfig, ArbitratorReputation, ArbitratorVote, DisclosureGrant, DisputeResolution,
-    MultiSigConfig, PriceTrigger, Proposal, ProposalAction, ProposalStatus, Subscription,
-    SubscriptionTier, TemplateTerms, TemplateVersion, Trade, TradePrivacy, TradeStatus,
-    TradeTemplate, TriggerAction, UserTier, UserTierInfo, VotingSummary,
+    ArbitrationConfig, ArbitratorReputation, ArbitratorVote, CrossChainInfo, DisputeResolution,
+    InsurancePolicy, KycStatus, MultiSigConfig, OptionalMetadata, PriceTrigger, Subscription,
+    SubscriptionTier, TemplateTerms, TemplateVersion, TierConfig, TierStatus, TierThresholds,
+    Trade, TradeStatus, TradeTemplate, TriggerAction, UserCompliance, UserTier, UserTierInfo,
+    VotingSummary, MAX_INSURANCE_PREMIUM_BPS, MAX_METADATA_SIZE,
 };
 pub use queries::{PageParams, SortDirection, TradeFilter, TradeSortField, TradeStats};
 pub use oracle::{OracleEntry, PriceData, PriceValidation};
-pub use bridge::{BridgeProvider, CrossChainTrade, BridgeAttestation, BridgeValidation};
+pub use bridge::{BridgeAttestation, BridgeProvider, BridgeValidation, CrossChainTrade};
 pub use upgrade::{RollbackSnapshot, UpgradeProposal};
 pub use proxy::*;
-
-use storage::{
-    add_accumulated_fees, add_currency_fees, get_accumulated_fees, get_admin, get_currency_fees,
-    get_fee_bps, get_trade, get_trade_counter, get_usdc_token, has_arbitrator, has_rated,
-    increment_trade_counter, is_initialized, is_paused, mark_rated, remove_arbitrator,
-    save_arbitrator, save_arbitrator_reputation, save_trade, set_accumulated_fees, set_admin,
-    set_currency_fees, set_fee_bps, set_initialized, set_paused, set_trade_counter, set_usdc_token,
-    set_currency_fees, set_fee_bps, set_initialized, set_paused, set_trade_counter,
-    set_usdc_token, CrossChainInfo, InsurancePolicy,
-    has_insurance_provider, save_insurance_provider, remove_insurance_provider,
-};
 
 fn require_initialized(env: &Env) -> Result<(), ContractError> {
     if !storage::is_initialized(env) {
@@ -66,6 +51,15 @@ fn require_not_paused(env: &Env) -> Result<(), ContractError> {
     if storage::is_paused(env) {
         return Err(ContractError::ContractPaused);
     }
+    Ok(())
+}
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
+    let admin = storage::get_admin(env)?;
+    if &admin != caller {
+        return Err(ContractError::Unauthorized);
+    }
+    caller.require_auth();
     Ok(())
 }
 
@@ -146,6 +140,11 @@ impl StellarEscrowContract {
         Ok(())
     }
 
+    /// Return the current admin address, if the contract is initialized.
+    pub fn get_admin(env: Env) -> Option<Address> {
+        storage::get_admin(&env).ok()
+    }
+
     pub fn register_arbitrator(env: Env, arbitrator: Address) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -218,13 +217,11 @@ impl StellarEscrowContract {
 
     pub fn is_arbitrator_registered(env: Env, arbitrator: Address) -> bool {
         storage::has_arbitrator(&env, &arbitrator)
+    }
+
     // -------------------------------------------------------------------------
     // Multi-Signature Arbitration
     // -------------------------------------------------------------------------
-
-    /// Create a trade with multi-signature arbitration.
-    /// All arbitrators in `config` must be registered; threshold must be > 0
-    /// and ≤ arbitrators count.
 
     /// Cast a vote on a disputed multi-sig trade.
     pub fn cast_vote(
@@ -255,13 +252,12 @@ impl StellarEscrowContract {
         require_not_paused(&env)?;
         require_admin(&env, &admin)?;
         let resolution = multisig::resolve_expired_dispute(&env, trade_id, &admin)?;
-        let trade = get_trade(&env, trade_id)?;
-        StellarEscrowContract::execute_dispute_resolution(env, trade_id, resolution, trade)
+        let trade = storage::get_trade(&env, trade_id)?;
+        execute_dispute_resolution(env, trade_id, resolution, trade)
     }
 
-    // -------------------------------------------------------------------------
-
     /// Rate the arbitrator of a disputed trade (buyer or seller, once each).
+    /// Only applies to single-arbitrator trades.
     pub fn rate_arbitrator(
         env: Env,
         trade_id: u64,
@@ -269,10 +265,10 @@ impl StellarEscrowContract {
         stars: u32,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
-        let trade = get_trade(&env, trade_id)?;
+        let trade = storage::get_trade(&env, trade_id)?;
         let arbitrator = match &trade.arbitrator {
-            Some(arb) => arb.clone(),
-            None => return Err(ContractError::NoArbitrator),
+            Some(ArbitrationConfig::Single(addr)) => addr.clone(),
+            Some(ArbitrationConfig::MultiSig(_)) | None => return Err(ContractError::NoArbitrator),
         };
         rater.require_auth();
         reputation::rate_arbitrator(
@@ -336,8 +332,11 @@ impl StellarEscrowContract {
         Ok(())
     }
 
+    /// Get platform fee in basis points
     pub fn get_platform_fee_bps(env: Env) -> Result<u32, ContractError> {
         storage::get_fee_bps(&env)
+    }
+
     // -------------------------------------------------------------------------
     // Trade Insurance
     // -------------------------------------------------------------------------
@@ -346,50 +345,103 @@ impl StellarEscrowContract {
     pub fn register_insurance_provider(env: Env, provider: Address) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
-        let admin = get_admin(&env)?;
+        let admin = storage::get_admin(&env)?;
         admin.require_auth();
-        save_insurance_provider(&env, &provider);
+        storage::save_insurance_provider(&env, &provider);
         events::emit_insurance_provider_registered(&env, provider);
         Ok(())
     }
 
     /// Remove an insurance provider (admin only)
-    pub fn remove_insurance_provider_fn(env: Env, provider: Address) -> Result<(), ContractError> {
+    pub fn remove_insurance_provider(env: Env, provider: Address) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
-        let admin = get_admin(&env)?;
+        let admin = storage::get_admin(&env)?;
         admin.require_auth();
-        remove_insurance_provider(&env, &provider);
+        storage::remove_insurance_provider(&env, &provider);
         events::emit_insurance_provider_removed(&env, provider);
         Ok(())
+    }
+
+    pub fn is_insurance_provider_registered(env: Env, provider: Address) -> bool {
+        storage::has_insurance_provider(&env, &provider)
     }
 
     /// Purchase optional trade insurance for a created trade
     pub fn purchase_insurance(
         env: Env,
         trade_id: u64,
-        buyer: Address,
         provider: Address,
+        premium_bps: u32,
+        coverage: u64,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
-        insurance::purchase_insurance(&env, trade_id, buyer, provider)
+        if premium_bps > MAX_INSURANCE_PREMIUM_BPS {
+            return Err(ContractError::InsurancePremiumTooHigh);
+        }
+        if !storage::has_insurance_provider(&env, &provider) {
+            return Err(ContractError::InsuranceProviderNotRegistered);
+        }
+        let trade = storage::get_trade(&env, trade_id)?;
+        if trade.status != TradeStatus::Funded && trade.status != TradeStatus::Completed {
+            return Err(ContractError::InvalidStatus);
+        }
+        trade.buyer.require_auth();
+        let premium = trade
+            .amount
+            .checked_mul(premium_bps as u64)
+            .ok_or(ContractError::Overflow)?
+            .checked_div(10_000)
+            .ok_or(ContractError::Overflow)?;
+        usdc_client(&env)?.transfer(&trade.buyer, &provider, &(premium as i128));
+        storage::save_insurance_policy(
+            &env,
+            trade_id,
+            &InsurancePolicy {
+                provider: provider.clone(),
+                premium,
+                coverage,
+                claimed: false,
+            },
+        );
+        events::emit_insurance_purchased(&env, trade_id, provider, premium, coverage);
+        Ok(())
     }
 
-    /// Claim insurance payout for a disputed trade
+    /// Claim insurance payout for a disputed or completed trade. `payout` is
+    /// capped at the policy's coverage amount.
     pub fn claim_insurance(
         env: Env,
         trade_id: u64,
         recipient: Address,
+        payout: u64,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
-        require_not_paused(&env)?;
-        insurance::claim_insurance(&env, trade_id, recipient)
+        let trade = storage::get_trade(&env, trade_id)?;
+        if trade.status != TradeStatus::Disputed && trade.status != TradeStatus::Completed {
+            return Err(ContractError::InsuranceClaimNotEligible);
+        }
+        let mut policy = storage::get_insurance_policy(&env, trade_id).ok_or(ContractError::TradeNotInsured)?;
+        if policy.claimed {
+            return Err(ContractError::InsuranceAlreadyClaimed);
+        }
+        policy.provider.require_auth();
+        let actual_payout = if payout > policy.coverage { policy.coverage } else { payout };
+        usdc_client(&env)?.transfer(&policy.provider, &recipient, &(actual_payout as i128));
+        policy.claimed = true;
+        storage::save_insurance_policy(&env, trade_id, &policy);
+        events::emit_insurance_claimed(&env, trade_id, actual_payout, recipient);
+        Ok(())
     }
 
     /// Calculate insurance premium for a given trade amount
     pub fn get_insurance_premium(env: Env, amount: u64, provider: Address) -> u64 {
         insurance::calculate_premium(&env, amount, &provider)
+    }
+
+    pub fn get_insurance_policy(env: Env, trade_id: u64) -> Option<InsurancePolicy> {
+        storage::get_insurance_policy(&env, trade_id)
     }
 
     pub fn set_user_compliance(
@@ -469,7 +521,6 @@ impl StellarEscrowContract {
         metadata: OptionalMetadata,
         expiry_time: Option<u64>,
         currency: Option<Address>,
-        metadata: Option<soroban_sdk::String>,
         trigger: Option<PriceTrigger>,
     ) -> Result<u64, ContractError> {
         require_initialized(&env)?;
@@ -486,46 +537,37 @@ impl StellarEscrowContract {
                 if !storage::has_arbitrator(&env, &addr) {
                     return Err(ContractError::ArbitratorNotRegistered);
                 }
-                Some(addr)
+                Some(ArbitrationConfig::Single(addr))
             }
             None => None,
         };
-        let trade_id = storage::increment_trade_counter(&env)?;
-        }
-        if let Some(ref meta) = metadata {
-            validate_metadata(meta)?;
-        }
         // Default to USDC when no currency specified (backward compat)
-        let token = currency.unwrap_or(get_usdc_token(&env)?);
-        validate_metadata(&metadata)?;
-        let trade_id = increment_trade_counter(&env)?;
-        let fee_bps = get_fee_bps(&env)?;
+        let token = currency.unwrap_or(storage::get_usdc_token(&env)?);
+        let trade_id = storage::increment_trade_counter(&env)?;
+        let fee_bps = storage::get_fee_bps(&env)?;
         let effective_bps = tiers::effective_fee_bps(&env, &seller, fee_bps);
         let discount = subscription::subscription_discount_bps(&env, &seller);
         let final_bps = effective_bps.saturating_sub(discount);
         let fee = amount
             .checked_mul(final_bps as u64)
             .ok_or(ContractError::Overflow)?
-            .checked_div(10000)
+            .checked_div(10_000)
             .ok_or(ContractError::Overflow)?;
-
-        let fee = calc_fee(&env, &seller, amount)?;
-        let arbitrator_config = arbitrator.map(ArbitrationConfig::Single);
         let trade = Trade {
             id: trade_id,
             seller: seller.clone(),
             buyer: buyer.clone(),
             amount,
             fee,
-            arbitrator: arbitrator_config,
+            arbitrator: arbitration,
             status: TradeStatus::Created,
             expiry_time,
-            currency: token,
+            currency: token.clone(),
             metadata,
             trigger,
         };
-        save_trade(&env, trade_id, &trade);
-        events::emit_trade_created(&env, trade_id, seller.clone(), buyer.clone(), amount);
+        storage::save_trade(&env, trade_id, &trade);
+        events::emit_trade_created(&env, trade_id, seller.clone(), buyer.clone(), amount, token);
         events::emit_compliance_passed(&env, trade_id, seller, buyer, amount);
         analytics::on_trade_created(&env, amount, &trade.seller, &trade.buyer);
         Ok(trade_id)
@@ -541,7 +583,7 @@ impl StellarEscrowContract {
         multisig_config: MultiSigConfig,
         expiry_time: Option<u64>,
         currency: Option<Address>,
-        metadata: Option<soroban_sdk::String>,
+        metadata: OptionalMetadata,
         trigger: Option<PriceTrigger>,
     ) -> Result<u64, ContractError> {
         require_initialized(&env)?;
@@ -551,7 +593,7 @@ impl StellarEscrowContract {
         }
 
         // Validate multi-sig configuration
-        if multisig_config.arbitrators.len() < multisig_config.threshold as u32 {
+        if multisig_config.arbitrators.len() < multisig_config.threshold {
             return Err(ContractError::InvalidMultiSigConfig);
         }
         if multisig_config.threshold == 0 {
@@ -561,7 +603,7 @@ impl StellarEscrowContract {
         // Validate all arbitrators are registered
         for i in 0..multisig_config.arbitrators.len() {
             let arb = multisig_config.arbitrators.get(i).unwrap();
-            if !has_arbitrator(&env, &arb) {
+            if !storage::has_arbitrator(&env, &arb) {
                 return Err(ContractError::ArbitratorNotRegistered);
             }
         }
@@ -577,32 +619,27 @@ impl StellarEscrowContract {
         seller.require_auth();
         validate_user_compliance(&env, &seller, amount)?;
         validate_user_compliance(&env, &buyer, amount)?;
-
-        if let Some(ref meta) = metadata {
-            validate_metadata(meta)?;
-        }
-
-        // Default to USDC when no currency specified (backward compat)
-        let token = currency.unwrap_or(get_usdc_token(&env)?);
         validate_metadata(&metadata)?;
 
-        let trade_id = increment_trade_counter(&env)?;
-        let fee = calc_fee(&env, &seller, amount)?;
+        // Default to USDC when no currency specified (backward compat)
+        let token = currency.unwrap_or(storage::get_usdc_token(&env)?);
+
+        let trade_id = storage::increment_trade_counter(&env)?;
         let trade = Trade {
             id: trade_id,
             seller: seller.clone(),
             buyer: buyer.clone(),
             amount,
             fee: calc_fee(&env, amount)?,
-            arbitrator: arbitration,
+            arbitrator: Some(ArbitrationConfig::MultiSig(multisig_config)),
             status: TradeStatus::Created,
-            expiry_time: None,
-            currency: storage::get_usdc_token(&env)?,
+            expiry_time,
+            currency: token.clone(),
             metadata,
             trigger,
         };
         storage::save_trade(&env, trade_id, &trade);
-        events::emit_trade_created(&env, trade_id, seller.clone(), buyer.clone(), amount, trade.currency.clone());
+        events::emit_trade_created(&env, trade_id, seller.clone(), buyer.clone(), amount, token);
         events::emit_compliance_passed(&env, trade_id, seller, buyer, amount);
         analytics::on_trade_created(&env, amount, &trade.seller, &trade.buyer);
         Ok(trade_id)
@@ -651,29 +688,11 @@ impl StellarEscrowContract {
         }
         trade.buyer.require_auth();
         let payout = trade.amount.checked_sub(trade.fee).ok_or(ContractError::Overflow)?;
-        // Single token transfer using the trade's currency directly (no extra USDC lookup).
-        let token_client = TokenClient::new(&env, &trade.currency);
-        token_client.transfer(&env.current_contract_address(), &trade.seller, &(payout as i128));
-        // Atomic read-modify-write avoids a separate get + set call for per-currency fees.
-        add_currency_fees(&env, &trade.currency, trade.fee)?;
-        tiers::record_volume(&env, &trade.seller, trade.amount)?;
-        tiers::record_volume(&env, &trade.buyer, trade.amount)?;
-        let payout = trade
-            .amount
-            .checked_sub(trade.fee)
-            .ok_or(ContractError::Overflow)?;
         let token_client = token::Client::new(&env, &trade.currency);
-        let contract_balance = token_client.balance(&env.current_contract_address());
-        let required_balance = trade.amount as i128;
-        if contract_balance < required_balance {
-            token_client.transfer(
-                &trade.buyer,
-                &env.current_contract_address(),
-                &(required_balance - contract_balance),
-            );
-        }
         token_client.transfer(&env.current_contract_address(), &trade.seller, &(payout as i128));
         storage::add_accumulated_fees(&env, trade.fee)?;
+        tiers::record_volume(&env, &trade.seller, trade.amount)?;
+        tiers::record_volume(&env, &trade.buyer, trade.amount)?;
         events::emit_trade_confirmed(&env, trade_id, payout, trade.fee);
         analytics::on_trade_completed(&env, trade.fee);
         Ok(())
@@ -685,9 +704,6 @@ impl StellarEscrowContract {
         let mut trade = storage::get_trade(&env, trade_id)?;
         if trade.status != TradeStatus::Created {
             return Err(ContractError::InvalidStatus);
-    pub fn raise_dispute(env: Env, trade_id: u64, caller: Address) -> Result<(), ContractError> {
-        if !is_initialized(&env) {
-            return Err(ContractError::NotInitialized);
         }
         trade.seller.require_auth();
         trade.status = TradeStatus::Cancelled;
@@ -724,6 +740,8 @@ impl StellarEscrowContract {
 
     /// Use `DisputeResolution::Partial { buyer_bps }` for a split:
     /// `buyer_bps` is the buyer's share of the net payout in basis points (0–10000).
+    /// Only applies to single-arbitrator trades — multi-sig trades resolve via
+    /// `cast_vote` consensus or `resolve_expired_dispute`.
     pub fn resolve_dispute(
         env: Env,
         trade_id: u64,
@@ -735,56 +753,13 @@ impl StellarEscrowContract {
         if trade.status != TradeStatus::Disputed {
             return Err(ContractError::InvalidStatus);
         }
-        let arbitrator = match trade.arbitrator.clone() {
-            Some(addr) => addr,
+        let arbitrator = match &trade.arbitrator {
+            Some(ArbitrationConfig::Single(addr)) => addr.clone(),
+            Some(ArbitrationConfig::MultiSig(_)) => return Err(ContractError::InvalidMultiSigConfig),
             None => return Err(ContractError::NoArbitrator),
         };
         arbitrator.require_auth();
-        let net = trade
-            .amount
-            .checked_sub(trade.fee)
-            .ok_or(ContractError::Overflow)?;
-        let token_client = token::Client::new(&env, &trade.currency);
-        match resolution.clone() {
-            DisputeResolution::ReleaseToBuyer => {
-                token_client.transfer(&env.current_contract_address(), &trade.buyer, &(net as i128));
-                events::emit_dispute_resolved(&env, trade_id, resolution, trade.buyer);
-            }
-            DisputeResolution::ReleaseToSeller => {
-                token_client.transfer(&env.current_contract_address(), &trade.seller, &(net as i128));
-                events::emit_dispute_resolved(&env, trade_id, resolution, trade.seller);
-            }
-            DisputeResolution::Partial(buyer_bps) => {
-                if buyer_bps > 10_000 {
-                    return Err(ContractError::InvalidSplitBps);
-                }
-                let buyer_amount = net
-                    .checked_mul(buyer_bps as u64)
-                    .ok_or(ContractError::Overflow)?
-                    .checked_div(10_000)
-                    .ok_or(ContractError::Overflow)?;
-                let seller_amount = net
-                    .checked_sub(buyer_amount)
-                    .ok_or(ContractError::Overflow)?;
-                if buyer_amount > 0 {
-                    token_client.transfer(
-                        &env.current_contract_address(),
-                        &trade.buyer,
-                        &(buyer_amount as i128),
-                    );
-                }
-                if seller_amount > 0 {
-                    token_client.transfer(
-                        &env.current_contract_address(),
-                        &trade.seller,
-                        &(seller_amount as i128),
-                    );
-                }
-                events::emit_partial_resolved(&env, trade_id, buyer_amount, seller_amount, trade.fee);
-            }
-        }
-        storage::add_accumulated_fees(&env, trade.fee)?;
-        Ok(())
+        execute_dispute_resolution(env, trade_id, resolution, trade)
     }
 
     pub fn get_trade(env: Env, trade_id: u64) -> Result<Trade, ContractError> {
@@ -792,7 +767,7 @@ impl StellarEscrowContract {
     }
 
     /// Withdraw accumulated protocol fees for a specific currency to a recipient.
-    /// Only the admin may call this. Panics if `amount` exceeds the available balance.
+    /// Only the admin may call this.
     pub fn withdraw_fees(
         env: Env,
         admin: Address,
@@ -848,11 +823,6 @@ impl StellarEscrowContract {
         storage::get_accumulated_fees(&env)
     }
 
-    /// Get platform fee in basis points
-    pub fn get_platform_fee_bps(env: Env) -> Result<u32, ContractError> {
-        get_fee_bps(&env)
-    }
-
     // -------------------------------------------------------------------------
     // Advanced Query Functions
     // -------------------------------------------------------------------------
@@ -893,7 +863,7 @@ impl StellarEscrowContract {
         priority: u32,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
-        get_admin(&env)?.require_auth();
+        storage::get_admin(&env)?.require_auth();
         oracle::register_oracle(&env, &base, &quote, oracle, priority)
     }
 
@@ -905,7 +875,7 @@ impl StellarEscrowContract {
         oracle: Address,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
-        get_admin(&env)?.require_auth();
+        storage::get_admin(&env)?.require_auth();
         oracle::remove_oracle(&env, &base, &quote, &oracle)
     }
 
@@ -948,7 +918,7 @@ impl StellarEscrowContract {
     pub fn execute_price_trigger(env: Env, trade_id: u64) -> Result<(), ContractError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
-        let mut trade = get_trade(&env, trade_id)?;
+        let mut trade = storage::get_trade(&env, trade_id)?;
         let trigger = match &trade.trigger {
             Some(t) => t.clone(),
             None => return Err(ContractError::NoTrigger),
@@ -980,14 +950,12 @@ impl StellarEscrowContract {
                         &(payout as i128),
                     );
                     // Add fee to contract's accumulated revenue
-                    let current_fees = storage::get_currency_fees(&env, &trade.currency);
-                    let new_fees = current_fees.checked_add(trade.fee).ok_or(ContractError::Overflow)?;
-                    storage::set_currency_fees(&env, &trade.currency, new_fees);
+                    storage::add_currency_fees(&env, &trade.currency, trade.fee)?;
                     storage::add_accumulated_fees(&env, trade.fee)?;
                     trade.status = TradeStatus::Triggered;
                 }
             }
-            save_trade(&env, trade_id, &trade);
+            storage::save_trade(&env, trade_id, &trade);
             events::emit_trigger_executed(&env, trade_id, &trigger.action);
         } else {
             return Err(ContractError::PriceConditionNotMet);
@@ -1023,15 +991,15 @@ impl StellarEscrowContract {
     /// Allowed even while paused so funds can always be recovered.
     pub fn emergency_withdraw(env: Env, to: Address) -> Result<(), ContractError> {
         require_initialized(&env)?;
-        let admin = get_admin(&env)?;
+        let admin = storage::get_admin(&env)?;
         admin.require_auth();
-        let token = get_usdc_token(&env)?;
+        let token = storage::get_usdc_token(&env)?;
         let token_client = token::Client::new(&env, &token);
         let balance = token_client.balance(&env.current_contract_address());
         if balance > 0 {
             token_client.transfer(&env.current_contract_address(), &to, &balance);
         }
-        set_accumulated_fees(&env, 0);
+        storage::set_accumulated_fees(&env, 0);
         events::emit_emergency_withdraw(&env, to, balance as u64);
         Ok(())
     }
@@ -1069,7 +1037,7 @@ impl StellarEscrowContract {
 
     /// Query the effective fee bps for a user's next trade.
     pub fn get_effective_fee_bps(env: Env, user: Address) -> Result<u32, ContractError> {
-        let base = get_fee_bps(&env)?;
+        let base = storage::get_fee_bps(&env)?;
         Ok(tiers::effective_fee_bps(&env, &user, base))
     }
 
@@ -1104,7 +1072,7 @@ impl StellarEscrowContract {
     pub fn create_template(
         env: Env,
         owner: Address,
-        name: soroban_sdk::String,
+        name: String,
         terms: TemplateTerms,
     ) -> Result<u64, ContractError> {
         require_initialized(&env)?;
@@ -1117,7 +1085,7 @@ impl StellarEscrowContract {
         env: Env,
         caller: Address,
         template_id: u64,
-        name: soroban_sdk::String,
+        name: String,
         terms: TemplateTerms,
     ) -> Result<(), ContractError> {
         require_initialized(&env)?;
@@ -1131,6 +1099,15 @@ impl StellarEscrowContract {
         caller: Address,
         template_id: u64,
     ) -> Result<(), ContractError> {
+        require_initialized(&env)?;
+        caller.require_auth();
+        templates::deactivate_template(&env, &caller, template_id)
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-Chain Bridge (simple single-oracle flow)
+    // -------------------------------------------------------------------------
+
     pub fn set_bridge_oracle(env: Env, oracle: Address) -> Result<(), ContractError> {
         require_initialized(&env)?;
         storage::get_admin(&env)?.require_auth();
@@ -1162,7 +1139,7 @@ impl StellarEscrowContract {
                 if !storage::has_arbitrator(&env, &addr) {
                     return Err(ContractError::ArbitratorNotRegistered);
                 }
-                Some(addr)
+                Some(ArbitrationConfig::Single(addr))
             }
             None => None,
         };
@@ -1183,8 +1160,6 @@ impl StellarEscrowContract {
             expiry_time: None,
             currency: storage::get_usdc_token(&env)?,
             metadata: OptionalMetadata::None,
-            currency: get_usdc_token(&env)?,
-            metadata: None,
             trigger: None,
         };
         storage::save_trade(&env, trade_id, &trade);
@@ -1249,97 +1224,9 @@ impl StellarEscrowContract {
         storage::get_cross_chain_info(&env, trade_id)
     }
 
-    pub fn register_insurance_provider(
-        env: Env,
-        provider: Address,
-    ) -> Result<(), ContractError> {
-        require_initialized(&env)?;
-        storage::get_admin(&env)?.require_auth();
-        storage::save_insurance_provider(&env, &provider);
-        events::emit_insurance_provider_registered(&env, provider);
-        Ok(())
-    }
-
-    pub fn remove_insurance_provider(env: Env, provider: Address) -> Result<(), ContractError> {
-        require_initialized(&env)?;
-        storage::get_admin(&env)?.require_auth();
-        storage::remove_insurance_provider(&env, &provider);
-        events::emit_insurance_provider_removed(&env, provider);
-        Ok(())
-    }
-
-    pub fn is_insurance_provider_registered(env: Env, provider: Address) -> bool {
-        storage::has_insurance_provider(&env, &provider)
-    }
-
-    pub fn purchase_insurance(
-        env: Env,
-        trade_id: u64,
-        provider: Address,
-        premium_bps: u32,
-        coverage: u64,
-    ) -> Result<(), ContractError> {
-        require_initialized(&env)?;
-        require_not_paused(&env)?;
-        if premium_bps > MAX_INSURANCE_PREMIUM_BPS {
-            return Err(ContractError::InsurancePremiumTooHigh);
-        }
-        if !storage::has_insurance_provider(&env, &provider) {
-            return Err(ContractError::InsuranceProviderNotRegistered);
-        }
-        let trade = storage::get_trade(&env, trade_id)?;
-        if trade.status != TradeStatus::Funded && trade.status != TradeStatus::Completed {
-            return Err(ContractError::InvalidStatus);
-        }
-        trade.buyer.require_auth();
-        let premium = trade
-            .amount
-            .checked_mul(premium_bps as u64)
-            .ok_or(ContractError::Overflow)?
-            .checked_div(10_000)
-            .ok_or(ContractError::Overflow)?;
-        usdc_client(&env)?.transfer(&trade.buyer, &provider, &(premium as i128));
-        storage::save_insurance_policy(
-            &env,
-            trade_id,
-            &InsurancePolicy {
-                provider: provider.clone(),
-                premium,
-                coverage,
-                claimed: false,
-            },
-        );
-        events::emit_insurance_purchased(&env, trade_id, provider, premium, coverage);
-        Ok(())
-    }
-
-    pub fn claim_insurance(
-        env: Env,
-        trade_id: u64,
-        recipient: Address,
-        payout: u64,
-    ) -> Result<(), ContractError> {
-        require_initialized(&env)?;
-        let trade = storage::get_trade(&env, trade_id)?;
-        if trade.status != TradeStatus::Disputed && trade.status != TradeStatus::Completed {
-            return Err(ContractError::InsuranceClaimNotEligible);
-        }
-        let mut policy = storage::get_insurance_policy(&env, trade_id).ok_or(ContractError::TradeNotInsured)?;
-        if policy.claimed {
-            return Err(ContractError::InsuranceAlreadyClaimed);
-        }
-        policy.provider.require_auth();
-        let actual_payout = if payout > policy.coverage { policy.coverage } else { payout };
-        usdc_client(&env)?.transfer(&policy.provider, &recipient, &(actual_payout as i128));
-        policy.claimed = true;
-        storage::save_insurance_policy(&env, trade_id, &policy);
-        events::emit_insurance_claimed(&env, trade_id, actual_payout, recipient);
-        Ok(())
-    }
-
-    pub fn get_insurance_policy(env: Env, trade_id: u64) -> Option<InsurancePolicy> {
-        storage::get_insurance_policy(&env, trade_id)
-    }
+    // -------------------------------------------------------------------------
+    // Analytics
+    // -------------------------------------------------------------------------
 
     pub fn get_platform_metrics(env: Env) -> PlatformMetrics {
         analytics::get_metrics(&env)
@@ -1372,6 +1259,62 @@ impl StellarEscrowContract {
     pub fn get_analytics_by_period(env: Env, start_time: u64, end_time: u64) -> PeriodAnalytics {
         analytics::get_analytics_by_period(&env, start_time, end_time)
     }
+}
+
+/// Shared fund-transfer logic for a resolved dispute, used by both
+/// `resolve_dispute` (single-arbitrator direct resolution) and
+/// `resolve_expired_dispute` (multi-sig force-resolve after timeout).
+fn execute_dispute_resolution(
+    env: Env,
+    trade_id: u64,
+    resolution: DisputeResolution,
+    trade: Trade,
+) -> Result<(), ContractError> {
+    let net = trade
+        .amount
+        .checked_sub(trade.fee)
+        .ok_or(ContractError::Overflow)?;
+    let token_client = token::Client::new(&env, &trade.currency);
+    match resolution.clone() {
+        DisputeResolution::ReleaseToBuyer => {
+            token_client.transfer(&env.current_contract_address(), &trade.buyer, &(net as i128));
+            events::emit_dispute_resolved(&env, trade_id, resolution, trade.buyer);
+        }
+        DisputeResolution::ReleaseToSeller => {
+            token_client.transfer(&env.current_contract_address(), &trade.seller, &(net as i128));
+            events::emit_dispute_resolved(&env, trade_id, resolution, trade.seller);
+        }
+        DisputeResolution::Partial { buyer_bps } => {
+            if buyer_bps > 10_000 {
+                return Err(ContractError::InvalidSplitBps);
+            }
+            let buyer_amount = net
+                .checked_mul(buyer_bps as u64)
+                .ok_or(ContractError::Overflow)?
+                .checked_div(10_000)
+                .ok_or(ContractError::Overflow)?;
+            let seller_amount = net
+                .checked_sub(buyer_amount)
+                .ok_or(ContractError::Overflow)?;
+            if buyer_amount > 0 {
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &trade.buyer,
+                    &(buyer_amount as i128),
+                );
+            }
+            if seller_amount > 0 {
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &trade.seller,
+                    &(seller_amount as i128),
+                );
+            }
+            events::emit_partial_resolved(&env, trade_id, buyer_amount, seller_amount, trade.fee);
+        }
+    }
+    storage::add_accumulated_fees(&env, trade.fee)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/contract/src/storage.rs
+++ b/contract/src/storage.rs
@@ -1,66 +1,15 @@
-use soroban_sdk::{symbol_short, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol, Vec};
 
 use crate::errors::ContractError;
 use crate::types::{
-    ArbitratorReputation, ArbitratorVote, ArbitrationConfig, CrossChainInfo, DisclosureGrant,
-    InsurancePolicy, MultiSigConfig, Proposal, Subscription, TierConfig, Trade, TradePrivacy,
-    TradeTemplate, UserTierInfo, VotingSummary,
+    ArbitratorReputation, ArbitratorVote, CrossChainInfo, InsurancePolicy, Subscription,
+    TierConfig, Trade, TradeTemplate, UserCompliance, UserTierInfo,
 };
 
 // ---------------------------------------------------------------------------
-// Instance storage keys — symbol_short! is the most gas-efficient encoding
-// for keys stored in instance storage (loaded on every contract call).
+// Instance storage keys — a single DataKey enum for straightforward
+// single-value / single-address-indexed fields.
 // ---------------------------------------------------------------------------
-fn key_init()     -> Symbol { symbol_short!("INIT") }
-fn key_admin()    -> Symbol { symbol_short!("ADMIN") }
-fn key_usdc()     -> Symbol { symbol_short!("USDC") }
-fn key_fee_bps()  -> Symbol { symbol_short!("FEE_BPS") }
-fn key_counter()  -> Symbol { symbol_short!("COUNTER") }
-fn key_acc_fees() -> Symbol { symbol_short!("ACC_FEES") }
-fn key_paused()   -> Symbol { symbol_short!("PAUSED") }
-fn key_tier_cfg() -> Symbol { symbol_short!("TIER_CFG") }
-fn key_tmpl_ctr() -> Symbol { symbol_short!("TMPL_CTR") }
-fn key_version()  -> Symbol { symbol_short!("VERSION") }
-fn key_bridge()   -> Symbol { symbol_short!("BRIDGE") }
-fn key_gov_tkn()  -> Symbol { symbol_short!("GOV_TKN") }
-fn key_prop_ctr() -> Symbol { symbol_short!("PROP_CTR") }
-fn key_glob_lim() -> Symbol { symbol_short!("GLOB_LIM") }
-
-// ---------------------------------------------------------------------------
-// Persistent storage key prefixes — single-char strings minimise key size,
-// directly reducing ledger entry bytes and CPU cost.
-// ---------------------------------------------------------------------------
-const TRADE_PREFIX:           &str = "T";
-const ARB_PREFIX:             &str = "A";
-const USER_TIER_PREFIX:       &str = "U";
-const TEMPLATE_PREFIX:        &str = "P";
-const XCHAIN_PREFIX:          &str = "X";
-const INS_PROVIDER_PREFIX:    &str = "IP";
-const INS_POLICY_PREFIX:      &str = "IPL";
-const CURRENCY_FEES_PREFIX:   &str = "CF";
-const USER_COMPLIANCE_PREFIX: &str = "UC";
-const USER_LIMIT_PREFIX:      &str = "UL";
-const JURISDICTION_PREFIX:    &str = "JR";
-const SUBSCRIPTION_PREFIX:    &str = "SB";
-const PROPOSAL_PREFIX:        &str = "PR";
-const VOTE_PREFIX:            &str = "VT";
-const DELEGATE_PREFIX:        &str = "DL";
-const ARB_REP_PREFIX:         &str = "AR";
-const ARB_RATED_PREFIX:       &str = "RT";
-const MULTISIG_VOTE_PREFIX:   &str = "MV";
-const TRADE_PRIVACY_PREFIX:   &str = "TP";
-const DISCLOSURE_PREFIX:      &str = "DC";
-
-// ---------------------------------------------------------------------------
-// Initialization
-// ---------------------------------------------------------------------------
-use soroban_sdk::{contracttype, Address, Env, String};
-
-use crate::{
-    errors::ContractError,
-    types::{CrossChainInfo, InsurancePolicy, Trade, UserCompliance},
-};
-
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
@@ -83,6 +32,32 @@ enum DataKey {
     InsuranceProvider(Address),
     InsurancePolicy(u64),
 }
+
+// ---------------------------------------------------------------------------
+// Persistent storage key prefixes for fields without a DataKey variant —
+// single-char strings minimise key size, directly reducing ledger entry
+// bytes and CPU cost.
+// ---------------------------------------------------------------------------
+const CURRENCY_FEES_PREFIX: &str = "CF";
+const USER_TIER_PREFIX: &str = "U";
+const TEMPLATE_PREFIX: &str = "P";
+const SUBSCRIPTION_PREFIX: &str = "SB";
+const ARB_FEE_PREFIX: &str = "AF";
+const ARB_LIST_KEY: &str = "ARBLIST";
+const MULTISIG_VOTE_PREFIX: &str = "MV";
+const ARB_REP_PREFIX: &str = "AR";
+const ARB_RATED_PREFIX: &str = "RT";
+
+fn key_tier_cfg() -> Symbol {
+    symbol_short!("TIER_CFG")
+}
+fn key_tmpl_ctr() -> Symbol {
+    symbol_short!("TMPL_CTR")
+}
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
 
 pub fn is_initialized(env: &Env) -> bool {
     env.storage().instance().get(&DataKey::Initialized).unwrap_or(false)
@@ -142,17 +117,14 @@ pub fn get_fee_bps(env: &Env) -> Result<u32, ContractError> {
 // ---------------------------------------------------------------------------
 
 pub fn set_trade_counter(env: &Env, counter: u64) {
-    env.storage().instance().set(&key_counter(), &counter);
-pub fn set_paused(env: &Env, paused: bool) {
-    env.storage().instance().set(&DataKey::Paused, &paused);
-}
-
-pub fn is_paused(env: &Env) -> bool {
-    env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
-}
-
-pub fn set_trade_counter(env: &Env, counter: u64) {
     env.storage().instance().set(&DataKey::TradeCounter, &counter);
+}
+
+pub fn get_trade_counter(env: &Env) -> Result<u64, ContractError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::TradeCounter)
+        .ok_or(ContractError::NotInitialized)
 }
 
 pub fn increment_trade_counter(env: &Env) -> Result<u64, ContractError> {
@@ -172,23 +144,28 @@ pub fn increment_trade_counter(env: &Env) -> Result<u64, ContractError> {
 // ---------------------------------------------------------------------------
 
 pub fn set_accumulated_fees(env: &Env, fees: u64) {
-    env.storage().instance().set(&key_acc_fees(), &fees);
+    env.storage().instance().set(&DataKey::AccumulatedFees, &fees);
 }
 
 pub fn get_accumulated_fees(env: &Env) -> Result<u64, ContractError> {
     env.storage()
         .instance()
-        .get(&key_acc_fees())
+        .get(&DataKey::AccumulatedFees)
         .ok_or(ContractError::NotInitialized)
 }
 
 /// Atomically add `delta` to the legacy accumulated-fees counter in a single
-/// read-modify-write, avoiding a separate get + set pair.
-pub fn add_accumulated_fees(env: &Env, delta: u64) -> Result<(), ContractError> {
-    let current: u64 = env.storage().instance().get(&key_acc_fees()).unwrap_or(0);
-    let new_fees = current.checked_add(delta).ok_or(ContractError::Overflow)?;
-    env.storage().instance().set(&key_acc_fees(), &new_fees);
-    Ok(())
+/// read-modify-write, avoiding a separate get + set pair. Returns the new total.
+pub fn add_accumulated_fees(env: &Env, delta: u64) -> Result<u64, ContractError> {
+    let updated = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&DataKey::AccumulatedFees)
+        .unwrap_or(0)
+        .checked_add(delta)
+        .ok_or(ContractError::Overflow)?;
+    env.storage().instance().set(&DataKey::AccumulatedFees, &updated);
+    Ok(updated)
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +208,7 @@ pub fn get_trade(env: &Env, trade_id: u64) -> Result<Trade, ContractError> {
 }
 
 // ---------------------------------------------------------------------------
-// Arbitrators
+// Arbitrators (registration flag)
 // ---------------------------------------------------------------------------
 
 pub fn save_arbitrator(env: &Env, arbitrator: &Address) {
@@ -247,15 +224,14 @@ pub fn remove_arbitrator(env: &Env, arbitrator: &Address) {
 }
 
 pub fn has_arbitrator(env: &Env, arbitrator: &Address) -> bool {
-    let key = (ARB_PREFIX, arbitrator);
-    env.storage().persistent().has(&key)
+    env.storage()
+        .persistent()
+        .has(&DataKey::Arbitrator(arbitrator.clone()))
 }
 
 // ---------------------------------------------------------------------------
 // Arbitrator self-registration with fee (Issue #120)
 // ---------------------------------------------------------------------------
-const ARB_FEE_PREFIX: &str = "AF";
-const ARB_LIST_KEY:   &str = "ARBLIST";
 
 /// Store an arbitrator's self-declared service fee (i128 stroops).
 pub fn save_arbitrator_fee(env: &Env, arbitrator: &Address, fee: i128) {
@@ -277,11 +253,11 @@ pub fn get_arbitrator_fee(env: &Env, arbitrator: &Address) -> i128 {
 
 /// Append `arbitrator` to the persistent registry list (no-op if already present).
 pub fn add_to_arbitrator_list(env: &Env, arbitrator: &Address) {
-    let mut list: soroban_sdk::Vec<Address> = env
+    let mut list: Vec<Address> = env
         .storage()
         .persistent()
         .get(&ARB_LIST_KEY)
-        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+        .unwrap_or_else(|| Vec::new(env));
     for i in 0..list.len() {
         if list.get(i).unwrap() == *arbitrator {
             return;
@@ -293,12 +269,12 @@ pub fn add_to_arbitrator_list(env: &Env, arbitrator: &Address) {
 
 /// Remove `arbitrator` from the persistent registry list.
 pub fn remove_from_arbitrator_list(env: &Env, arbitrator: &Address) {
-    let list: soroban_sdk::Vec<Address> = env
+    let list: Vec<Address> = env
         .storage()
         .persistent()
         .get(&ARB_LIST_KEY)
-        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    let mut new_list = soroban_sdk::Vec::new(env);
+        .unwrap_or_else(|| Vec::new(env));
+    let mut new_list = Vec::new(env);
     for i in 0..list.len() {
         let a = list.get(i).unwrap();
         if a != *arbitrator {
@@ -309,11 +285,11 @@ pub fn remove_from_arbitrator_list(env: &Env, arbitrator: &Address) {
 }
 
 /// Return the full list of registered arbitrators.
-pub fn get_arbitrator_list(env: &Env) -> soroban_sdk::Vec<Address> {
+pub fn get_arbitrator_list(env: &Env) -> Vec<Address> {
     env.storage()
         .persistent()
         .get(&ARB_LIST_KEY)
-        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 // ---------------------------------------------------------------------------
@@ -362,11 +338,11 @@ pub fn clear_votes_for_trade(env: &Env, trade_id: u64, arbitrators: &Vec<Address
 // ---------------------------------------------------------------------------
 
 pub fn set_paused(env: &Env, paused: bool) {
-    env.storage().instance().set(&key_paused(), &paused);
+    env.storage().instance().set(&DataKey::Paused, &paused);
 }
 
 pub fn is_paused(env: &Env) -> bool {
-    env.storage().instance().get(&key_paused()).unwrap_or(false)
+    env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
 }
 
 // ---------------------------------------------------------------------------
@@ -399,14 +375,6 @@ pub fn get_user_tier(env: &Env, user: &Address) -> Option<UserTierInfo> {
 // User Compliance
 // ---------------------------------------------------------------------------
 
-pub fn save_user_compliance(env: &Env, user: &Address, compliance: &crate::types::UserCompliance) {
-    let key = (USER_COMPLIANCE_PREFIX, user);
-    env.storage().persistent().set(&key, compliance);
-    env.storage()
-        .persistent()
-        .has(&DataKey::Arbitrator(arbitrator.clone()))
-}
-
 pub fn save_user_compliance(env: &Env, user: &Address, compliance: &UserCompliance) {
     env.storage()
         .persistent()
@@ -437,13 +405,16 @@ pub fn get_user_trade_limit(env: &Env, user: &Address) -> u64 {
 // ---------------------------------------------------------------------------
 
 pub fn set_jurisdiction_rule(env: &Env, jurisdiction: &String, allowed: bool) {
-    let key = (JURISDICTION_PREFIX, jurisdiction);
-    env.storage().persistent().set(&key, &allowed);
+    env.storage()
+        .persistent()
+        .set(&DataKey::JurisdictionRule(jurisdiction.clone()), &allowed);
 }
 
 pub fn is_jurisdiction_allowed(env: &Env, jurisdiction: &String) -> bool {
-    let key = (JURISDICTION_PREFIX, jurisdiction);
-    env.storage().persistent().get(&key).unwrap_or(true)
+    env.storage()
+        .persistent()
+        .get(&DataKey::JurisdictionRule(jurisdiction.clone()))
+        .unwrap_or(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -451,11 +422,14 @@ pub fn is_jurisdiction_allowed(env: &Env, jurisdiction: &String) -> bool {
 // ---------------------------------------------------------------------------
 
 pub fn set_global_trade_limit(env: &Env, limit: u64) {
-    env.storage().instance().set(&key_glob_lim(), &limit);
+    env.storage().instance().set(&DataKey::GlobalTradeLimit, &limit);
 }
 
 pub fn get_global_trade_limit(env: &Env) -> u64 {
-    env.storage().instance().get(&key_glob_lim()).unwrap_or(u64::MAX)
+    env.storage()
+        .instance()
+        .get(&DataKey::GlobalTradeLimit)
+        .unwrap_or(u64::MAX)
 }
 
 // ---------------------------------------------------------------------------
@@ -507,116 +481,27 @@ pub fn remove_subscription(env: &Env, subscriber: &Address) {
 }
 
 // ---------------------------------------------------------------------------
-// Governance — use symbol_short! keys for instance storage, short string
-// prefixes for persistent storage to minimise serialisation cost.
-// ---------------------------------------------------------------------------
-
-pub fn set_gov_token(env: &Env, token: &Address) {
-    env.storage().instance().set(&key_gov_tkn(), token);
-}
-
-pub fn get_gov_token(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&key_gov_tkn())
-}
-
-pub fn get_proposal_counter(env: &Env) -> u64 {
-    env.storage().instance().get(&key_prop_ctr()).unwrap_or(0)
-}
-
-pub fn increment_proposal_counter(env: &Env) -> Result<u64, ContractError> {
-    let next = get_proposal_counter(env)
-        .checked_add(1)
-        .ok_or(ContractError::Overflow)?;
-    env.storage().instance().set(&key_prop_ctr(), &next);
-    Ok(next)
-}
-
-pub fn save_proposal(env: &Env, id: u64, proposal: &Proposal) {
-    let key = (PROPOSAL_PREFIX, id);
-    env.storage().persistent().set(&key, proposal);
-}
-
-pub fn get_proposal(env: &Env, id: u64) -> Result<Proposal, ContractError> {
-    let key = (PROPOSAL_PREFIX, id);
-    env.storage()
-        .persistent()
-        .get(&key)
-        .ok_or(ContractError::ProposalNotFound)
-}
-
-pub fn has_voted(env: &Env, proposal_id: u64, voter: &Address) -> bool {
-    let key = (VOTE_PREFIX, proposal_id, voter);
-    env.storage().persistent().has(&key)
-}
-
-pub fn mark_voted(env: &Env, proposal_id: u64, voter: &Address) {
-    let key = (VOTE_PREFIX, proposal_id, voter);
-    env.storage().persistent().set(&key, &true);
-}
-
-pub fn set_delegate(env: &Env, delegator: &Address, delegatee: &Address) {
-    let key = (DELEGATE_PREFIX, delegator);
-    env.storage().persistent().set(&key, delegatee);
-}
-
-pub fn get_delegate(env: &Env, delegator: &Address) -> Option<Address> {
-    let key = (DELEGATE_PREFIX, delegator);
-    env.storage().persistent().get(&key)
-}
-
-pub fn remove_delegate(env: &Env, delegator: &Address) {
-    let key = (DELEGATE_PREFIX, delegator);
-    env.storage().persistent().remove(&key);
-}
-
-// ---------------------------------------------------------------------------
 // Arbitrator Reputation
 // ---------------------------------------------------------------------------
-pub fn set_jurisdiction_rule(env: &Env, jurisdiction: &String, allowed: bool) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::JurisdictionRule(jurisdiction.clone()), &allowed);
+
+pub fn get_arbitrator_reputation(env: &Env, arbitrator: &Address) -> ArbitratorReputation {
+    let key = (ARB_REP_PREFIX, arbitrator);
+    env.storage().persistent().get(&key).unwrap_or(ArbitratorReputation {
+        rating_sum: 0,
+        rating_count: 0,
+        resolved_count: 0,
+        total_disputes: 0,
+    })
 }
 
-pub fn is_jurisdiction_allowed(env: &Env, jurisdiction: &String) -> bool {
-    env.storage()
-        .persistent()
-        .get(&DataKey::JurisdictionRule(jurisdiction.clone()))
-        .unwrap_or(true)
+pub fn save_arbitrator_reputation(env: &Env, arbitrator: &Address, rep: &ArbitratorReputation) {
+    let key = (ARB_REP_PREFIX, arbitrator);
+    env.storage().persistent().set(&key, rep);
 }
 
-pub fn set_global_trade_limit(env: &Env, limit: u64) {
-    env.storage().instance().set(&DataKey::GlobalTradeLimit, &limit);
-}
-
-pub fn get_global_trade_limit(env: &Env) -> u64 {
-    env.storage()
-        .instance()
-        .get(&DataKey::GlobalTradeLimit)
-        .unwrap_or(u64::MAX)
-}
-
-pub fn set_accumulated_fees(env: &Env, fees: u64) {
-    env.storage().instance().set(&DataKey::AccumulatedFees, &fees);
-}
-
-pub fn get_accumulated_fees(env: &Env) -> Result<u64, ContractError> {
-    env.storage()
-        .instance()
-        .get(&DataKey::AccumulatedFees)
-        .ok_or(ContractError::NotInitialized)
-}
-
-pub fn add_accumulated_fees(env: &Env, delta: u64) -> Result<u64, ContractError> {
-    let updated = env
-        .storage()
-        .instance()
-        .get::<_, u64>(&DataKey::AccumulatedFees)
-        .unwrap_or(0)
-        .checked_add(delta)
-        .ok_or(ContractError::Overflow)?;
-    env.storage().instance().set(&DataKey::AccumulatedFees, &updated);
-    Ok(updated)
+pub fn has_rated(env: &Env, trade_id: u64, rater: &Address) -> bool {
+    let key = (ARB_RATED_PREFIX, trade_id, rater);
+    env.storage().persistent().has(&key)
 }
 
 pub fn mark_rated(env: &Env, trade_id: u64, rater: &Address) {
@@ -636,12 +521,8 @@ pub fn get_version(env: &Env) -> u32 {
     env.storage().instance().get(&DataKey::Version).unwrap_or(1)
 }
 
-pub fn set_version(env: &Env, version: u32) {
-    env.storage().instance().set(&key_version(), &version);
-}
-
 // ---------------------------------------------------------------------------
-// Bridge Oracle
+// Bridge Oracle (simple single-oracle cross-chain flow)
 // ---------------------------------------------------------------------------
 
 pub fn set_bridge_oracle(env: &Env, oracle: &Address) {
@@ -653,7 +534,7 @@ pub fn get_bridge_oracle(env: &Env) -> Option<Address> {
 }
 
 // ---------------------------------------------------------------------------
-// Cross-Chain Info
+// Cross-Chain Info (simple single-oracle cross-chain flow)
 // ---------------------------------------------------------------------------
 
 pub fn save_cross_chain_info(env: &Env, trade_id: u64, info: &CrossChainInfo) {
@@ -701,37 +582,6 @@ pub fn save_insurance_policy(env: &Env, trade_id: u64, policy: &InsurancePolicy)
 }
 
 pub fn get_insurance_policy(env: &Env, trade_id: u64) -> Option<InsurancePolicy> {
-    let key = (INS_POLICY_PREFIX, trade_id);
-    env.storage().persistent().get(&key)
-}
-
-// ---------------------------------------------------------------------------
-// Privacy
-// ---------------------------------------------------------------------------
-
-pub fn save_trade_privacy(env: &Env, trade_id: u64, privacy: &TradePrivacy) {
-    let key = (TRADE_PRIVACY_PREFIX, trade_id);
-    env.storage().persistent().set(&key, privacy);
-}
-
-pub fn get_trade_privacy(env: &Env, trade_id: u64) -> Option<TradePrivacy> {
-    let key = (TRADE_PRIVACY_PREFIX, trade_id);
-    env.storage().persistent().get(&key)
-}
-
-pub fn save_disclosure_grant(env: &Env, trade_id: u64, grantee: &Address, grant: &DisclosureGrant) {
-    let key = (DISCLOSURE_PREFIX, trade_id, grantee);
-    env.storage().persistent().set(&key, grant);
-}
-
-pub fn get_disclosure_grant(env: &Env, trade_id: u64, grantee: &Address) -> Option<DisclosureGrant> {
-    let key = (DISCLOSURE_PREFIX, trade_id, grantee);
-    env.storage().persistent().get(&key)
-}
-
-pub fn remove_disclosure_grant(env: &Env, trade_id: u64, grantee: &Address) {
-    let key = (DISCLOSURE_PREFIX, trade_id, grantee);
-    env.storage().persistent().remove(&key);
     env.storage()
         .persistent()
         .get(&DataKey::InsurancePolicy(trade_id))

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -79,7 +79,7 @@ fn test_update_fee_invalid() {
 #[test]
 fn test_create_trade() {
     let (_, _, _, seller, buyer, _, client) = setup();
-    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None);
     assert_eq!(id, 1);
     let trade = client.get_trade(&id);
     assert_eq!(trade.status, TradeStatus::Created);
@@ -99,7 +99,7 @@ fn test_create_trade_with_compliance_rules() {
     client.set_user_trade_limit(&admin, &seller, &2_000_000u64);
     client.set_global_trade_limit(&admin, &3_000_000u64);
 
-    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None);
     assert_eq!(id, 1);
 }
 
@@ -119,7 +119,7 @@ fn test_create_trade_fails_for_unverified_kyc() {
     client.set_user_compliance(&admin, &seller, &seller_compliance);
     client.set_user_compliance(&admin, &buyer, &buyer_compliance);
 
-    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None).is_err());
+    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None).is_err());
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn test_create_trade_fails_for_jurisdiction_block() {
     client.set_user_compliance(&admin, &buyer, &compliant);
     client.set_jurisdiction_rule(&admin, &soroban_sdk::String::from_str(&env, "CN"), &false);
 
-    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None).is_err());
+    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None).is_err());
 }
 
 #[test]
@@ -149,19 +149,19 @@ fn test_create_trade_fails_for_amount_limit() {
     client.set_user_compliance(&admin, &buyer, &compliant);
     client.set_user_trade_limit(&admin, &seller, &500_000u64);
 
-    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None).is_err());
+    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None).is_err());
 }
 
 #[test]
 fn test_create_trade_zero_amount_fails() {
     let (_, _, _, seller, buyer, _, client) = setup();
-    assert!(client.try_create_trade(&seller, &buyer, &0u64, &None, &OptionalMetadata::None).is_err());
+    assert!(client.try_create_trade(&seller, &buyer, &0u64, &None, &OptionalMetadata::None, &None, &None, &None).is_err());
 }
 
 #[test]
 fn test_fund_trade() {
     let (env, token_addr, _, seller, buyer, _, client) = setup();
-    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, 1_000_000);
     client.fund_trade(&id);
     assert_eq!(client.get_trade(&id).status, TradeStatus::Funded);
@@ -171,7 +171,7 @@ fn test_fund_trade() {
 fn test_complete_and_confirm_trade() {
     let (env, token_addr, _, seller, buyer, _, client) = setup();
     let amount = 1_000_000u64;
-    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id);
     client.complete_trade(&id);
@@ -185,7 +185,7 @@ fn test_complete_and_confirm_trade() {
 #[test]
 fn test_cancel_trade() {
     let (_, _, _, seller, buyer, _, client) = setup();
-    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None);
     client.cancel_trade(&id);
     assert_eq!(client.get_trade(&id).status, TradeStatus::Cancelled);
 }
@@ -195,7 +195,7 @@ fn test_dispute_and_resolve_to_buyer() {
     let (env, token_addr, _, seller, buyer, arbitrator, client) = setup();
     client.register_arbitrator(&arbitrator);
     let amount = 1_000_000u64;
-    let id = client.create_trade(&seller, &buyer, &amount, &Some(arbitrator.clone()), &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &Some(arbitrator.clone()), &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id);
     client.raise_dispute(&id, &buyer);
@@ -210,14 +210,14 @@ fn test_dispute_and_resolve_to_buyer() {
 fn test_withdraw_fees() {
     let (env, token_addr, _, seller, buyer, _, client) = setup();
     let amount = 1_000_000u64;
-    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id);
     client.complete_trade(&id);
     client.confirm_receipt(&id);
 
     let recipient = Address::generate(&env);
-    client.withdraw_fees(&recipient);
+    client.withdraw_fees_legacy(&recipient);
     assert_eq!(token::Client::new(&env, &token_addr).balance(&recipient), 10_000i128);
     assert_eq!(client.get_accumulated_fees(), 0u64);
 }
@@ -227,7 +227,7 @@ fn test_pause_and_unpause() {
     let (_, _, _, seller, buyer, _, client) = setup();
     client.pause();
     assert!(client.is_paused());
-    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None).is_err());
+    assert!(client.try_create_trade(&seller, &buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None).is_err());
     client.unpause();
     assert!(!client.is_paused());
 }
@@ -236,7 +236,7 @@ fn test_pause_and_unpause() {
 fn test_no_fees_to_withdraw_fails() {
     let (env, _, _, _, _, _, client) = setup();
     let recipient = Address::generate(&env);
-    assert!(client.try_withdraw_fees(&recipient).is_err());
+    assert!(client.try_withdraw_fees_legacy(&recipient).is_err());
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn setup_insurance() -> (Env, Address, Address, Address, Address, StellarEscrowC
 }
 
 fn funded_trade(env: &Env, token_addr: &Address, seller: &Address, buyer: &Address, client: &StellarEscrowContractClient) -> u64 {
-    let id = client.create_trade(seller, buyer, &1_000_000u64, &None, &OptionalMetadata::None);
+    let id = client.create_trade(seller, buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None);
     token::Client::new(env, token_addr).approve(buyer, &client.address, &1_000_000i128, &200u32);
     client.fund_trade(&id);
     id
@@ -446,7 +446,7 @@ fn test_claim_insurance() {
     let arb = Address::generate(&env);
     client.register_arbitrator(&arb);
     // re-create a trade with arbitrator for dispute
-    let id2 = client.create_trade(&seller, &buyer, &1_000_000u64, &Some(arb.clone()), &OptionalMetadata::None);
+    let id2 = client.create_trade(&seller, &buyer, &1_000_000u64, &Some(arb.clone()), &OptionalMetadata::None, &None, &None, &None);
     token::Client::new(&env, &token_addr).approve(&buyer, &client.address, &1_000_000i128, &200u32);
     client.fund_trade(&id2);
     client.purchase_insurance(&id2, &provider, &100u32, &500_000u64);
@@ -470,7 +470,7 @@ fn test_claim_insurance_double_claim_fails() {
 
     let arb = Address::generate(&env);
     client.register_arbitrator(&arb);
-    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &Some(arb.clone()), &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &Some(arb.clone()), &OptionalMetadata::None, &None, &None, &None);
     token::Client::new(&env, &token_addr).approve(&buyer, &client.address, &1_000_000i128, &200u32);
     client.fund_trade(&id);
     client.purchase_insurance(&id, &provider, &100u32, &500_000u64);
@@ -489,7 +489,7 @@ fn test_claim_capped_at_coverage() {
 
     let arb = Address::generate(&env);
     client.register_arbitrator(&arb);
-    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &Some(arb.clone()), &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &1_000_000u64, &Some(arb.clone()), &OptionalMetadata::None, &None, &None, &None);
     token::Client::new(&env, &token_addr).approve(&buyer, &client.address, &1_000_000i128, &200u32);
     client.fund_trade(&id);
     // coverage = 50_000
@@ -524,7 +524,7 @@ fn test_analytics_volume_and_unique_addresses() {
     let (env, token_addr, _, seller, buyer, _, client) = setup();
     let amount = 1_000_000u64;
 
-    client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
 
     let result = client.analytics_query(&crate::analytics::TimeWindow::AllTime);
     assert_eq!(result.all_time.metrics.total_volume, amount);
@@ -534,7 +534,7 @@ fn test_analytics_volume_and_unique_addresses() {
 
     // second trade with same addresses — unique count must not grow
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
-    client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     let result2 = client.analytics_query(&crate::analytics::TimeWindow::AllTime);
     assert_eq!(result2.unique_addresses, 2);
     assert_eq!(result2.all_time.metrics.total_volume, amount * 2);
@@ -546,7 +546,7 @@ fn test_analytics_success_rate() {
     let amount = 1_000_000u64;
 
     // Complete one trade
-    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id);
     client.complete_trade(&id);
@@ -564,7 +564,7 @@ fn test_analytics_dispute_rate() {
     let amount = 1_000_000u64;
     client.register_arbitrator(&arbitrator);
 
-    let id = client.create_trade(&seller, &buyer, &amount, &Some(arbitrator.clone()), &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &Some(arbitrator.clone()), &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id);
     client.raise_dispute(&id, &buyer);
@@ -581,14 +581,14 @@ fn test_analytics_mixed_success_rate() {
     client.register_arbitrator(&arbitrator);
 
     // Trade 1: completed
-    let id1 = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    let id1 = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id1);
     client.complete_trade(&id1);
     client.confirm_receipt(&id1);
 
     // Trade 2: disputed (counts as terminal)
-    let id2 = client.create_trade(&seller, &buyer, &amount, &Some(arbitrator.clone()), &OptionalMetadata::None);
+    let id2 = client.create_trade(&seller, &buyer, &amount, &Some(arbitrator.clone()), &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id2);
     client.raise_dispute(&id2, &buyer);
@@ -603,7 +603,7 @@ fn test_analytics_window_metrics_track_trades() {
     let (_, _, _, seller, buyer, _, client) = setup();
     let amount = 500_000u64;
 
-    client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
 
     let result = client.analytics_query(&crate::analytics::TimeWindow::Last24h);
     assert_eq!(result.window.trades_created, 1);
@@ -615,7 +615,7 @@ fn test_analytics_active_trades() {
     let (env, token_addr, _, seller, buyer, _, client) = setup();
     let amount = 1_000_000u64;
 
-    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     let result = client.analytics_query(&crate::analytics::TimeWindow::AllTime);
     assert_eq!(result.all_time.active_trades, 1);
 
@@ -679,6 +679,9 @@ fn test_get_arbitrators_returns_all_registered() {
     let list = client.get_arbitrators();
     assert!(list.contains(&arb1));
     assert!(list.contains(&arb2));
+}
+
+// ---------------------------------------------------------------------------
 // Issue #122 — withdraw_fees (per-currency)
 // ---------------------------------------------------------------------------
 
@@ -686,7 +689,7 @@ fn test_get_arbitrators_returns_all_registered() {
 fn test_withdraw_fees_per_currency_succeeds() {
     let (env, token_addr, _, seller, buyer, _, client) = setup();
     let amount = 1_000_000u64;
-    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None);
+    let id = client.create_trade(&seller, &buyer, &amount, &None, &OptionalMetadata::None, &None, &None, &None);
     fund(&env, &token_addr, &buyer, &client.address, amount as i128);
     client.fund_trade(&id);
     client.complete_trade(&id);

--- a/contract/src/types.rs
+++ b/contract/src/types.rs
@@ -1,7 +1,118 @@
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contracttype, Address, String, Vec};
 
 pub const MAX_METADATA_SIZE: u32 = 1024;
 pub const MAX_INSURANCE_PREMIUM_BPS: u32 = 1000;
+
+// ---------------------------------------------------------------------------
+// Tiers — thresholds below are inferred (no source specified a value) and
+// should be reviewed as a product/business decision, not treated as final.
+// Assumes 6-decimal token units (i.e. USDC-style stroops).
+// ---------------------------------------------------------------------------
+pub const TIER_SILVER_THRESHOLD: u64 = 10_000_000_000; // 10,000 units
+pub const TIER_GOLD_THRESHOLD: u64 = 100_000_000_000; // 100,000 units
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UserTier {
+    Bronze,
+    Silver,
+    Gold,
+    Custom,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserTierInfo {
+    pub tier: UserTier,
+    pub total_volume: u64,
+    pub custom_fee_bps: Option<u32>,
+}
+
+/// Admin-configured fee schedule per tier.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TierConfig {
+    pub bronze_fee_bps: u32,
+    pub silver_fee_bps: u32,
+    pub gold_fee_bps: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions — prices/discounts below are inferred placeholders (no source
+// specified values) and should be reviewed as a product/business decision.
+// Duration uses the same ~5s/ledger conversion already established by
+// upgrade.rs's timelock constants.
+// ---------------------------------------------------------------------------
+pub const SUBSCRIPTION_DURATION_LEDGERS: u32 = 518_400; // ~30 days at ~5s/ledger
+pub const SUB_PRICE_BASIC: u64 = 10_000_000; // 10 units
+pub const SUB_PRICE_PRO: u64 = 50_000_000; // 50 units
+pub const SUB_PRICE_ENTERPRISE: u64 = 200_000_000; // 200 units
+pub const SUB_DISCOUNT_BASIC_BPS: u32 = 500; // 5%
+pub const SUB_DISCOUNT_PRO_BPS: u32 = 1_500; // 15%
+pub const SUB_DISCOUNT_ENTERPRISE_BPS: u32 = 3_000; // 30%
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SubscriptionTier {
+    Basic,
+    Pro,
+    Enterprise,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Subscription {
+    pub subscriber: Address,
+    pub tier: SubscriptionTier,
+    pub expires_at: u32,
+    pub renewed_at: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Trade templates
+// ---------------------------------------------------------------------------
+pub const TEMPLATE_MAX_VERSIONS: u32 = 20;
+pub const TEMPLATE_NAME_MAX_LEN: u32 = 128;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TemplateTerms {
+    pub description: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TemplateVersion {
+    pub version: u32,
+    pub terms: TemplateTerms,
+    pub created_at: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TradeTemplate {
+    pub id: u64,
+    pub owner: Address,
+    pub name: String,
+    pub current_version: u32,
+    pub versions: Vec<TemplateVersion>,
+    pub active: bool,
+    pub created_at: u32,
+    pub updated_at: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Arbitrator reputation
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArbitratorReputation {
+    pub rating_sum: u32,
+    pub rating_count: u32,
+    pub resolved_count: u32,
+    pub total_disputes: u32,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -44,7 +155,6 @@ pub enum TradeStatus {
     Completed,
     Disputed,
     Cancelled,
-    AwaitingBridge,
     AwaitingBridge, // cross-chain: waiting for bridge oracle confirmation
     BridgeFailed,   // cross-chain: bridge attestation failed
     Triggered,      // price-based trigger executed
@@ -55,13 +165,47 @@ pub enum TradeStatus {
 pub enum DisputeResolution {
     ReleaseToBuyer,
     ReleaseToSeller,
-    Partial(u32),
+    /// `buyer_bps`: buyer's share of the net payout, in basis points (0-10000).
+    Partial { buyer_bps: u32 },
+}
+
+// ---------------------------------------------------------------------------
+// Multi-signature arbitration
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultiSigConfig {
+    pub arbitrators: Vec<Address>,
+    pub threshold: u32,
+    pub voting_started_at: Option<u64>,
+    pub voting_timeout_seconds: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArbitratorVote {
+    pub arbitrator: Address,
+    pub resolution: DisputeResolution,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VotingSummary {
+    pub total_arbitrators: u32,
+    pub votes_cast: u32,
+    pub threshold: u32,
+    pub has_consensus: bool,
+    pub consensus_resolution: Option<DisputeResolution>,
+    pub voting_expired: bool,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ArbitrationConfig {
     Single(Address),
+    MultiSig(MultiSigConfig),
 }
 
 // ---------------------------------------------------------------------------
@@ -95,13 +239,11 @@ pub struct Trade {
     pub buyer: Address,
     pub amount: u64,
     pub fee: u64,
-    pub arbitrator: Option<Address>,
+    pub arbitrator: Option<ArbitrationConfig>,
     pub status: TradeStatus,
     pub expiry_time: Option<u64>,
     pub currency: Address,
     pub metadata: OptionalMetadata,
-    /// Optional JSON-like string metadata (product info, shipping details, etc.)
-    pub metadata: Option<String>,
     /// Optional price-based trigger
     pub trigger: Option<PriceTrigger>,
 }

--- a/contract/tests/common/mod.rs
+++ b/contract/tests/common/mod.rs
@@ -77,6 +77,9 @@ pub fn create_trade(h: &Harness, amount: u64) -> u64 {
         &amount,
         &None,
         &OptionalMetadata::None,
+        &None,
+        &None,
+        &None,
     )
 }
 
@@ -87,6 +90,9 @@ pub fn create_disputed_trade(h: &Harness, amount: u64) -> u64 {
         &amount,
         &Some(h.arbitrator.clone()),
         &OptionalMetadata::None,
+        &None,
+        &None,
+        &None,
     );
     approve_funding(h, amount as i128);
     h.client.fund_trade(&id);

--- a/contract/tests/edge_cases.rs
+++ b/contract/tests/edge_cases.rs
@@ -39,7 +39,7 @@ fn edge_rejects_partial_resolution_above_100_percent() {
 
     assert!(
         h.client
-            .try_resolve_dispute(&id, &DisputeResolution::Partial(10_001))
+            .try_resolve_dispute(&id, &DisputeResolution::Partial { buyer_bps: 10_001 })
             .is_err()
     );
 }
@@ -95,6 +95,9 @@ fn edge_rejects_insurance_purchase_for_unfunded_trade() {
         &1_000_000u64,
         &None,
         &OptionalMetadata::None,
+        &None,
+        &None,
+        &None,
     );
 
     assert!(

--- a/contract/tests/integration.rs
+++ b/contract/tests/integration.rs
@@ -17,7 +17,7 @@ fn integration_happy_path_accumulates_and_withdraws_fees() {
     h.client.confirm_receipt(&id);
 
     let recipient = Address::generate(&h.env);
-    h.client.withdraw_fees(&recipient);
+    h.client.withdraw_fees_legacy(&recipient);
 
     assert_eq!(token::Client::new(&h.env, &h.token_addr).balance(&h.seller), 990_000);
     assert_eq!(token::Client::new(&h.env, &h.token_addr).balance(&recipient), 10_000);
@@ -34,13 +34,16 @@ fn integration_dispute_partial_resolution_preserves_fee_accounting() {
         &1_000_000u64,
         &Some(h.arbitrator.clone()),
         &OptionalMetadata::None,
+        &None,
+        &None,
+        &None,
     );
 
     approve_funding(&h, 1_000_000);
     h.client.fund_trade(&id);
     h.client.raise_dispute(&id, &h.buyer);
     h.client
-        .resolve_dispute(&id, &DisputeResolution::Partial(4_000));
+        .resolve_dispute(&id, &DisputeResolution::Partial { buyer_bps: 4_000 });
 
     assert_eq!(h.client.get_trade(&id).status, TradeStatus::Disputed);
     assert_eq!(h.client.get_accumulated_fees(), 10_000);
@@ -91,6 +94,9 @@ fn integration_insurance_claim_flow_pays_out_provider_coverage() {
         &1_000_000u64,
         &Some(h.arbitrator.clone()),
         &OptionalMetadata::None,
+        &None,
+        &None,
+        &None,
     );
 
     approve_funding(&h, 1_000_000);

--- a/contract/tests/performance.rs
+++ b/contract/tests/performance.rs
@@ -56,6 +56,9 @@ fn perf_benchmark_dispute_and_insurance_path() {
             &1_000_000u64,
             &Some(h.arbitrator.clone()),
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
         approve_funding(&h, 1_000_000);
         h.client.fund_trade(&id);

--- a/contract/tests/security.rs
+++ b/contract/tests/security.rs
@@ -17,7 +17,7 @@ fn security_blocks_state_changes_while_paused() {
     assert!(h.client.try_complete_trade(&id).is_err());
     assert!(
         h.client
-            .try_create_trade(&h.seller, &h.buyer, &1_000_000u64, &None, &OptionalMetadata::None)
+            .try_create_trade(&h.seller, &h.buyer, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None)
             .is_err()
     );
 }
@@ -73,6 +73,9 @@ fn security_only_registered_arbitrators_can_back_disputed_trades() {
                 &1_000_000u64,
                 &Some(rogue_arbitrator),
                 &OptionalMetadata::None,
+                &None,
+                &None,
+                &None,
             )
             .is_err()
     );
@@ -95,7 +98,7 @@ fn security_rejects_fee_withdrawal_when_pool_is_empty() {
     let h = setup();
     let recipient = Address::generate(&h.env);
 
-    assert!(h.client.try_withdraw_fees(&recipient).is_err());
+    assert!(h.client.try_withdraw_fees_legacy(&recipient).is_err());
 }
 
 #[test]

--- a/contract/tests/stress.rs
+++ b/contract/tests/stress.rs
@@ -110,6 +110,9 @@ fn create_n_trades(h: &Harness, n: u32) -> std::vec::Vec<u64> {
             &1_000_000u64,
             &None,
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
         ids.push(id);
     }
@@ -131,7 +134,10 @@ fn run_happy_path(h: &Harness) -> u64 {
         &1_000_000u64,
         &None,
         &OptionalMetadata::None,
-    );
+            &None,
+            &None,
+            &None,
+        );
     h.client.fund_trade(&id);
     h.client.complete_trade(&id);
     h.client.confirm_receipt(&id);
@@ -152,7 +158,10 @@ fn run_dispute_cycle(h: &Harness) {
         &1_000_000u64,
         &Some(h.arbitrator.clone()),
         &OptionalMetadata::None,
-    );
+            &None,
+            &None,
+            &None,
+        );
     h.client.fund_trade(&id);
     h.client.raise_dispute(&id, &buyer);
     h.client.resolve_dispute(
@@ -257,6 +266,9 @@ fn bench_create_trade_instructions() {
             &1_000_000u64,
             &None,
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
     });
 
@@ -290,6 +302,9 @@ fn bench_full_happy_path_instructions() {
             &1_000_000u64,
             &None,
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
         h.client.fund_trade(&id);
         h.client.complete_trade(&id);
@@ -326,6 +341,9 @@ fn bench_dispute_cycle_instructions() {
             &1_000_000u64,
             &Some(h.arbitrator.clone()),
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
         h.client.fund_trade(&id);
         h.client.raise_dispute(&id, &buyer);
@@ -357,7 +375,7 @@ fn bench_fee_withdrawal_instructions() {
 
     let recipient = Address::generate(&h.env);
     let r = bench(&h.env, || {
-        h.client.withdraw_fees(&recipient);
+        h.client.withdraw_fees_legacy(&recipient);
     });
 
     std::println!(
@@ -388,6 +406,9 @@ fn monitor_resource_usage_scales_linearly() {
             &1_000_000u64,
             &None,
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
     });
 
@@ -399,7 +420,7 @@ fn monitor_resource_usage_scales_linearly() {
             mark_compliant(&h, &s);
             mark_compliant(&h, &b);
             h.client
-                .create_trade(&s, &b, &1_000_000u64, &None, &OptionalMetadata::None);
+                .create_trade(&s, &b, &1_000_000u64, &None, &OptionalMetadata::None, &None, &None, &None);
         }
     });
 
@@ -434,6 +455,9 @@ fn monitor_memory_usage_create_trade() {
             &1_000_000u64,
             &None,
             &OptionalMetadata::None,
+            &None,
+            &None,
+            &None,
         );
     });
 
@@ -462,7 +486,7 @@ fn stress_max_amount_trade() {
 
     let id = h
         .client
-        .create_trade(&seller, &buyer, &max_amount, &None, &OptionalMetadata::None);
+        .create_trade(&seller, &buyer, &max_amount, &None, &OptionalMetadata::None, &None, &None, &None);
     let trade = h.client.get_trade(&id);
     assert_eq!(trade.amount, max_amount);
 }


### PR DESCRIPTION
contract/src (and its test suites) had merge corruption from ~45+ uncoordinated commits: duplicate/conflicting definitions, unclosed function bodies, calls into modules that were never declared, and at least one referenced-but-never-defined function. In its committed state the crate could not compile at all. This reconstructs a single coherent, internally consistent version of every affected file.

Scope: contract/src/{lib,types,errors,storage,events,bridge}.rs, contract/src/test.rs, and contract/tests/{common/mod,edge_cases, integration,performance,security,stress}.rs. Deliberately out of scope (dead code not referenced by lib.rs's current API surface): amm.rs, emergency.rs, governance.rs (+ governance.test.rs), partial_release.rs, privacy.rs, social.rs, bridge.test.rs — left untouched for a future pass.

Highlights:

- types.rs: restored several type definitions (TierConfig, UserTier, UserTierInfo, Subscription, SubscriptionTier, TemplateTerms/Version, TradeTemplate, ArbitratorReputation, MultiSigConfig, ArbitratorVote, VotingSummary) that other modules imported but no longer existed here. Added the missing ArbitrationConfig::MultiSig variant — Trade.arbitrator is Option<ArbitrationConfig> (was incorrectly Option<Address> in one of the merged copies), matching how multisig.rs actually uses it. DisputeResolution::Partial became a struct variant ({ buyer_bps }) to match multisig.rs's usage. Tier/subscription pricing constants are inferred placeholders (no source specified values) and are flagged in-file for product review.

- errors.rs: deduplicated ~15 error variants that were declared 2-3 times each with conflicting discriminants; added InvalidRating/AlreadyRated (referenced by reputation.rs but never defined).

- storage.rs: reconciled two entire parallel storage backends (a DataKey enum scheme and a symbol/prefix scheme) that had been merged together, including cases where a field's getter and setter used different key encodings (e.g. has_arbitrator checked a different key than save_arbitrator wrote). Added get_trade_counter, has_rated, get/save_arbitrator_reputation — referenced elsewhere but missing here. Dropped the governance/privacy-only storage functions (dead code once those modules are out of scope).

- events.rs: removed an entire obsolete stub implementation (empty no-op functions) that had been left in place alongside the real implementation; deduplicated remaining duplicate event structs.

- bridge.rs: fixed calls to a nonexistent String::from_small_copy API (real soroban_sdk method is String::from_str).

- lib.rs: the centerpiece. Resolved duplicate/conflicting method bodies (get_platform_fee_bps, register/remove_insurance_provider, purchase_insurance, claim_insurance, create_trade, cancel_trade spliced into raise_dispute's signature), added the missing `mod` declarations for multisig/reputation/queries/oracle/bridge (present on disk, called from the impl block, but never wired in), and implemented execute_dispute_resolution — referenced by resolve_expired_dispute but never defined; its logic (and the default "refund the buyer" behavior) was already fully specified by existing doc comments and multisig::resolve_expired_dispute's return value, extracted as a shared helper also used by resolve_dispute. Added require_admin (referenced but missing; needed since multisig::resolve_expired_dispute trusts its caller to have already verified true-admin identity) and a public get_admin query (called by tests, no contract method existed).

  Two judgment calls were corrected mid-way based on hard test evidence rather than my initial "prefer the version that delegates to a dedicated module" heuristic: purchase_insurance/claim_insurance keep their inline premium_bps/coverage/payout parameters (every test call site uses that signature, not insurance.rs's simpler delegating one), and confirm_receipt posts fees to the legacy single-currency accumulator via add_accumulated_fees rather than add_currency_fees (multiple existing tests assert get_accumulated_fees() reflects post-confirmation fees).

- test.rs + contract/tests/*.rs: updated ~40 call sites across the test suites for signature changes (create_trade gained expiry_time/currency/ trigger parameters; withdraw_fees split into a new per-currency method and withdraw_fees_legacy; DisputeResolution::Partial's tuple form).

Notable gaps found but intentionally NOT fixed here (flagged for a separate decision):
- proxy.rs defines a second, independent #[contract] struct (EscrowProxy) that compiles into the same WASM as the escrow contract — architecturally unusual for a proxy pattern and likely not the intended design; left wired in (mod proxy; kept) rather than unilaterally restructured.
- subscription.rs (subscribe/renew/cancel) and upgrade.rs's full propose/execute/migrate/rollback flow have no public contract entry points — fully implemented modules with no way to actually call them.
- Tier volume thresholds and subscription pricing are inferred placeholders (see types.rs comments) pending real product numbers.

Verification: local `cargo check`/`cargo test` are blocked by a missing Windows SDK linker on this machine (unrelated to this change — even an empty crate's build-script dependencies fail to link here). Verified instead via static analysis: brace/paren balance, no duplicate top-level names, and a scripted cross-reference confirming every module::function() call, every crate::types/storage::{...} import, every ContractError variant reference, and every test call site's argument count resolves against its actual definition. Real compilation will be confirmed via GitHub Actions CI (Linux) once pushed.