### PR TITLE
fix: restore mangled function signature in indexer/src/database.rs

### DIFF
--- a/indexer/src/database.rs
+++ b/indexer/src/database.rs
@@ -58,7 +58,7 @@ impl Database {
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }
-(&self, event: &Event) -> Result<(), AppError> {
+
     /// Record a slow query to the slow_query_log table (fire-and-forget).
     /// Only logs queries exceeding `threshold_ms`.
     pub fn log_slow_query(


### PR DESCRIPTION
Rust CI has been failing with "this file contains an unclosed delimiter" pointing at the `impl Database {` block (opened line 53, never closed by EOF at line 2130).

Root cause: line 61 was a dangling fragment `(&self, event: &Event) -> Result<(), AppError> {` with no `pub async fn <name>` prefix, no body of its own, and no callers anywhere in the codebase (searched). The doc comment immediately after it ("Record a slow query...") actually belongs to the next method, log_slow_query — this orphaned opening brace was swallowing log_slow_query and everything after it as if nested inside it, which is why the outer impl block itself never found its matching close.

Since nothing in the codebase calls this fragment and no trace of its intended body survives, invented a plausible name/behavior for it would be guessing rather than restoring known intent. Removed the orphaned fragment instead, letting log_slow_query stand as its own top-level method again. Verified brace balance across the full file is now correct (net depth 0, never negative).

Note: this fixes the specific compile error CI reported, but three other indexer files (cache_service/mod.rs, event_monitor.rs, models.rs) have similar unresolved brace imbalances that will surface as the next compile error once this one is past. Tracked separately — not fixed in this change.